### PR TITLE
Include `pgettext` calls when extracting translatable string literals

### DIFF
--- a/site_scons/site_tools/gettexttool/__init__.py
+++ b/site_scons/site_tools/gettexttool/__init__.py
@@ -24,6 +24,7 @@ XGETTEXT_COMMON_ARGS = (
 	"--msgid-bugs-address='$gettext_package_bugs_address' "
 	"--package-name='$gettext_package_name' "
 	"--package-version='$gettext_package_version' "
+	"--keyword=pgettext:1c,2 "
 	"-c -o $TARGET $SOURCES"
 )
 


### PR DESCRIPTION
Fixes #2