### PR TITLE
Fix some linting issues in the template

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -35,14 +35,16 @@ It can span multiple lines."""),
 	"addon_lastTestedNVDAVersion": None,
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
-	# Ddo not change unless you know what you are doing!
+	# Do not change unless you know what you are doing!
 	"addon_updateChannel": None,
 }
 
 
+import os.path  # NOQA
+
+
 # Define the python files that are the sources of your add-on.
 # You can use glob expressions here, they will be expanded.
-# Fell free to import `os.path` at the top if you need to
 pythonSources = []
 
 # Files that contain strings for translation. Usually your python sources

--- a/buildVars.py
+++ b/buildVars.py
@@ -3,8 +3,11 @@
 # Build customizations
 # Change this file instead of sconstruct or manifest files, whenever possible.
 
+
 # Full getext (please don't change)
-_ = lambda x: x
+def _(arg):
+	return arg
+
 
 # Add-on information variables
 addon_info = {

--- a/buildVars.py
+++ b/buildVars.py
@@ -14,7 +14,8 @@ addon_info = {
 	# add-on Name/identifier, internal for NVDA
 	"addon_name": "addonTemplate",
 	# Add-on summary, usually the user visible name of the addon.
-	# Translators: Summary for this add-on to be shown on installation and add-on information found in Add-ons Manager.
+	# Translators: Summary for this add-on
+	# to be shown on installation and add-on information found in Add-ons Manager.
 	"addon_summary": _("Add-on user visible name"),
 	# Add-on description
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
@@ -32,7 +33,9 @@ It can span multiple lines."""),
 	"addon_minimumNVDAVersion": None,
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion": None,
-	# Add-on update channel (default is None, denoting stable releases, and for development releases, use "dev"; do not change unless you know what you are doing)
+	# Add-on update channel (default is None, denoting stable releases,
+	# and for development releases, use "dev".)
+	# Ddo not change unless you know what you are doing!
 	"addon_updateChannel": None,
 }
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -40,10 +40,9 @@ It can span multiple lines."""),
 }
 
 
-import os.path
-
 # Define the python files that are the sources of your add-on.
 # You can use glob expressions here, they will be expanded.
+# Fell free to import `os.path` at the top if you need to
 pythonSources = []
 
 # Files that contain strings for translation. Usually your python sources

--- a/sconstruct
+++ b/sconstruct
@@ -134,7 +134,8 @@ def createAddonBundleFromPath(path, dest):
 			for filename in filenames:
 				pathInBundle = os.path.join(relativePath, filename)
 				absPath = os.path.join(dir, filename)
-				if pathInBundle not in buildVars.excludedFiles: z.write(absPath, pathInBundle)
+				if pathInBundle not in buildVars.excludedFiles:
+					z.write(absPath, pathInBundle)
 	return dest
 
 

--- a/sconstruct
+++ b/sconstruct
@@ -171,7 +171,7 @@ addon = env.NVDAAddon(addonFile, env.Dir('addon'))
 
 langDirs = [f for f in env.Glob(os.path.join("addon", "locale", "*"))]
 
-#Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
+# Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
 for dir in langDirs:
 	poFile = dir.File(os.path.join("LC_MESSAGES", "nvda.po"))
 	moFile = env.gettextMoFile(poFile)
@@ -187,7 +187,7 @@ pythonFiles = expandGlobs(buildVars.pythonSources)
 for file in pythonFiles:
 	env.Depends(addon, file)
 
-#Convert markdown files to html
+# Convert markdown files to html
 # We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
 createAddonHelp("addon")
 for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):

--- a/sconstruct
+++ b/sconstruct
@@ -17,7 +17,7 @@ import buildVars
 def md2html(source, dest):
 	import markdown
 	lang = os.path.basename(os.path.dirname(source)).replace('_', '-')
-	title="{addonSummary} {addonVersion}".format(
+	title = "{addonSummary} {addonVersion}".format(
 		addonSummary=buildVars.addon_info["addon_summary"], addonVersion=buildVars.addon_info["addon_version"]
 	)
 	headerDic = {
@@ -44,16 +44,16 @@ def md2html(source, dest):
 
 
 def mdTool(env):
-	mdAction=env.Action(
-		lambda target,source,env: md2html(source[0].path, target[0].path),
-		lambda target,source,env: 'Generating %s'%target[0],
+	mdAction = env.Action(
+		lambda target, source, env: md2html(source[0].path, target[0].path),
+		lambda target, source, env: 'Generating % s' % target[0],
 	)
-	mdBuilder=env.Builder(
+	mdBuilder = env.Builder(
 		action=mdAction,
 		suffix='.html',
 		src_suffix='.md',
 	)
-	env['BUILDERS']['markdown']=mdBuilder
+	env['BUILDERS']['markdown'] = mdBuilder
 
 
 vars = Variables()
@@ -174,7 +174,7 @@ langDirs = [f for f in env.Glob(os.path.join("addon", "locale", "*"))]
 #Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
 for dir in langDirs:
 	poFile = dir.File(os.path.join("LC_MESSAGES", "nvda.po"))
-	moFile=env.gettextMoFile(poFile)
+	moFile = env.gettextMoFile(poFile)
 	env.Depends(moFile, poFile)
 	translatedManifest = env.NVDATranslatedManifest(
 		dir.File("manifest.ini"),
@@ -197,7 +197,7 @@ for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):
 
 # Pot target
 i18nFiles = expandGlobs(buildVars.i18nSources)
-gettextvars={
+gettextvars = {
 		'gettext_package_bugs_address': 'nvda-translations@groups.io',
 		'gettext_package_name': buildVars.addon_info['addon_name'],
 		'gettext_package_version': buildVars.addon_info['addon_version']
@@ -217,4 +217,4 @@ env.Depends(manifest, "buildVars.py")
 
 env.Depends(addon, manifest)
 env.Default(addon)
-env.Clean (addon, ['.sconsign.dblite', 'addon/doc/en/'])
+env.Clean(addon, ['.sconsign.dblite', 'addon/doc/en/'])

--- a/sconstruct
+++ b/sconstruct
@@ -198,10 +198,10 @@ for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):
 # Pot target
 i18nFiles = expandGlobs(buildVars.i18nSources)
 gettextvars = {
-		'gettext_package_bugs_address': 'nvda-translations@groups.io',
-		'gettext_package_name': buildVars.addon_info['addon_name'],
-		'gettext_package_version': buildVars.addon_info['addon_version']
-	}
+	'gettext_package_bugs_address': 'nvda-translations@groups.io',
+	'gettext_package_name': buildVars.addon_info['addon_name'],
+	'gettext_package_version': buildVars.addon_info['addon_version']
+}
 
 pot = env.gettextPotFile("${addon_name}.pot", i18nFiles, **gettextvars)
 env.Alias('pot', pot)

--- a/sconstruct
+++ b/sconstruct
@@ -13,6 +13,7 @@ sys.dont_write_bytecode = True
 
 import buildVars
 
+
 def md2html(source, dest):
 	import markdown
 	lang = os.path.basename(os.path.dirname(source)).replace('_', '-')
@@ -41,6 +42,7 @@ def md2html(source, dest):
 		f.write(htmlText)
 		f.write("\n</body>\n</html>")
 
+
 def mdTool(env):
 	mdAction=env.Action(
 		lambda target,source,env: md2html(source[0].path, target[0].path),
@@ -52,6 +54,7 @@ def mdTool(env):
 		src_suffix='.md',
 	)
 	env['BUILDERS']['markdown']=mdBuilder
+
 
 vars = Variables()
 vars.Add("version", "The version of this build", buildVars.addon_info["addon_version"])
@@ -77,6 +80,7 @@ buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
 
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
 
+
 def addonGenerator(target, source, env, for_signature):
 	action = env.Action(
 		lambda target, source, env: createAddonBundleFromPath(source[0].abspath, target[0].abspath) and None,
@@ -84,12 +88,14 @@ def addonGenerator(target, source, env, for_signature):
 	)
 	return action
 
+
 def manifestGenerator(target, source, env, for_signature):
 	action = env.Action(
 		lambda target, source, env: generateManifest(source[0].abspath, target[0].abspath) and None,
 		lambda target, source, env: "Generating manifest %s" % target[0]
 	)
 	return action
+
 
 def translatedManifestGenerator(target, source, env, for_signature):
 	dir = os.path.abspath(os.path.join(os.path.dirname(str(source[0])), ".."))
@@ -100,9 +106,11 @@ def translatedManifestGenerator(target, source, env, for_signature):
 	)
 	return action
 
+
 env['BUILDERS']['NVDAAddon'] = Builder(generator=addonGenerator)
 env['BUILDERS']['NVDAManifest'] = Builder(generator=manifestGenerator)
 env['BUILDERS']['NVDATranslatedManifest'] = Builder(generator=translatedManifestGenerator)
+
 
 def createAddonHelp(dir):
 	docsDir = os.path.join(dir, "doc")
@@ -114,6 +122,7 @@ def createAddonHelp(dir):
 		readmePath = os.path.join(docsDir, "en", "readme.md")
 		readmeTarget = env.Command(readmePath, "readme.md", Copy("$TARGET", "$SOURCE"))
 		env.Depends(addon, readmeTarget)
+
 
 def createAddonBundleFromPath(path, dest):
 	""" Creates a bundle from a directory that contains an addon manifest file."""
@@ -128,6 +137,7 @@ def createAddonBundleFromPath(path, dest):
 				if pathInBundle not in buildVars.excludedFiles: z.write(absPath, pathInBundle)
 	return dest
 
+
 def generateManifest(source, dest):
 	addon_info = buildVars.addon_info
 	with codecs.open(source, "r", "utf-8") as f:
@@ -135,6 +145,7 @@ def generateManifest(source, dest):
 	manifest = manifest_template.format(**addon_info)
 	with codecs.open(dest, "w", "utf-8") as f:
 		f.write(manifest)
+
 
 def generateTranslatedManifest(source, language, out):
 	# No ugettext in Python 3.
@@ -151,8 +162,10 @@ def generateTranslatedManifest(source, language, out):
 	with codecs.open(out, "w", "utf-8") as f:
 		f.write(result)
 
+
 def expandGlobs(files):
 	return [f for pattern in files for f in env.Glob(pattern)]
+
 
 addon = env.NVDAAddon(addonFile, env.Dir('addon'))
 

--- a/sconstruct
+++ b/sconstruct
@@ -16,7 +16,9 @@ import buildVars
 def md2html(source, dest):
 	import markdown
 	lang = os.path.basename(os.path.dirname(source)).replace('_', '-')
-	title="{addonSummary} {addonVersion}".format(addonSummary=buildVars.addon_info["addon_summary"], addonVersion=buildVars.addon_info["addon_version"])
+	title="{addonSummary} {addonVersion}".format(
+		addonSummary=buildVars.addon_info["addon_summary"], addonVersion=buildVars.addon_info["addon_version"]
+	)
 	headerDic = {
 		"[[!meta title=\"": "# ",
 		"\"]]": " #",
@@ -76,20 +78,26 @@ buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
 
 def addonGenerator(target, source, env, for_signature):
-	action = env.Action(lambda target, source, env : createAddonBundleFromPath(source[0].abspath, target[0].abspath) and None,
-	lambda target, source, env : "Generating Addon %s" % target[0])
+	action = env.Action(
+		lambda target, source, env: createAddonBundleFromPath(source[0].abspath, target[0].abspath) and None,
+		lambda target, source, env: "Generating Addon %s" % target[0]
+	)
 	return action
 
 def manifestGenerator(target, source, env, for_signature):
-	action = env.Action(lambda target, source, env : generateManifest(source[0].abspath, target[0].abspath) and None,
-	lambda target, source, env : "Generating manifest %s" % target[0])
+	action = env.Action(
+		lambda target, source, env: generateManifest(source[0].abspath, target[0].abspath) and None,
+		lambda target, source, env: "Generating manifest %s" % target[0]
+	)
 	return action
 
 def translatedManifestGenerator(target, source, env, for_signature):
 	dir = os.path.abspath(os.path.join(os.path.dirname(str(source[0])), ".."))
 	lang = os.path.basename(dir)
-	action = env.Action(lambda target, source, env : generateTranslatedManifest(source[1].abspath, lang, target[0].abspath) and None,
-	lambda target, source, env : "Generating translated manifest %s" % target[0])
+	action = env.Action(
+		lambda target, source, env: generateTranslatedManifest(source[1].abspath, lang, target[0].abspath) and None,
+		lambda target, source, env: "Generating translated manifest %s" % target[0]
+	)
 	return action
 
 env['BUILDERS']['NVDAAddon'] = Builder(generator=addonGenerator)
@@ -155,7 +163,10 @@ for dir in langDirs:
 	poFile = dir.File(os.path.join("LC_MESSAGES", "nvda.po"))
 	moFile=env.gettextMoFile(poFile)
 	env.Depends(moFile, poFile)
-	translatedManifest = env.NVDATranslatedManifest(dir.File("manifest.ini"), [moFile, os.path.join("manifest-translated.ini.tpl")])
+	translatedManifest = env.NVDATranslatedManifest(
+		dir.File("manifest.ini"),
+		[moFile, os.path.join("manifest-translated.ini.tpl")]
+	)
 	env.Depends(translatedManifest, ["buildVars.py"])
 	env.Depends(addon, [translatedManifest, moFile])
 
@@ -164,7 +175,8 @@ for file in pythonFiles:
 	env.Depends(addon, file)
 
 #Convert markdown files to html
-createAddonHelp("addon") # We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
+# We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
+createAddonHelp("addon")
 for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):
 	htmlFile = env.markdown(mdFile)
 	env.Depends(htmlFile, mdFile)
@@ -173,9 +185,9 @@ for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):
 # Pot target
 i18nFiles = expandGlobs(buildVars.i18nSources)
 gettextvars={
-		'gettext_package_bugs_address' : 'nvda-translations@groups.io',
-		'gettext_package_name' : buildVars.addon_info['addon_name'],
-		'gettext_package_version' : buildVars.addon_info['addon_version']
+		'gettext_package_bugs_address': 'nvda-translations@groups.io',
+		'gettext_package_name': buildVars.addon_info['addon_name'],
+		'gettext_package_version': buildVars.addon_info['addon_version']
 	}
 
 pot = env.gettextPotFile("${addon_name}.pot", i18nFiles, **gettextvars)

--- a/site_scons/site_tools/gettexttool/__init__.py
+++ b/site_scons/site_tools/gettexttool/__init__.py
@@ -47,6 +47,9 @@ def generate(env):
 		suffix=".pot")
 
 	env['BUILDERS']['gettextMergePotFile'] = env.Builder(
-		action=Action("xgettext " + "--omit-header --no-location " + XGETTEXT_COMMON_ARGS,
-			"Generating pot file $TARGET"),
-		suffix=".pot")
+		action=Action(
+			"xgettext " + "--omit-header --no-location " + XGETTEXT_COMMON_ARGS,
+			"Generating pot file $TARGET"
+		),
+		suffix=".pot"
+	)


### PR DESCRIPTION
Normally I would refrain from submitting pull requests which contains just Linter fixes, but many recent commits to master are dealing with issues detected by Linter.
This PR makes buildVars, gettexttool and most of the sconstruct compliant with Flake8 rules (note that config from the NVDA repository was used when linting). If this would  be accepted I intend to submit second PR which would deal with remaining issues in Sconstruct.