### PR TITLE
Final Linting and explanatory comments

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -4,7 +4,11 @@
 # Change this file instead of sconstruct or manifest files, whenever possible.
 
 
-# Full getext
+# Since some strings in `addon_info` are translatable,
+# we need to include them in the .po files.
+# Gettext recognizes only strings given as parameters to the `_` function.
+# To avoid initializing translations in this module we simply roll our own "fake" `_` function
+# which returns whatever is given to it as an argument.
 def _(arg):
 	return arg
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -44,7 +44,13 @@ It can span multiple lines."""),
 }
 
 # Define the python files that are the sources of your add-on.
-# You can use glob expressions here, they will be expanded.
+# You can either list every file (using ""/") as a path separator,
+# or use glob expressions.
+# For example to include all files with a ".py" extension from the "globalPlugins" dir of your add-on
+# the list can be written as follows:
+# pythonSources = ["addon/globalPlugins/*.py"]
+# For more information on SCons Glob expressions please take a loog at:
+# https://scons.org/doc/production/HTML/scons-user/apd.html
 pythonSources = []
 
 # Files that contain strings for translation. Usually your python sources

--- a/sconstruct
+++ b/sconstruct
@@ -9,6 +9,13 @@ import os
 import os.path
 import zipfile
 import sys
+
+# While names imported below are available by default in every SConscript
+# Linters aren't aware about them.
+# To avoid Flake8 F821 warnings about them they are imported explicitly.
+# When using other  Scons functions please add them to the line below.
+from SCons.Script import BoolVariable, Builder, Copy, Environment, Variables
+
 sys.dont_write_bytecode = True
 
 # Bytecode should not be written for build vars module to keep the repository root folder clean.
@@ -60,7 +67,6 @@ def mdTool(env):
 	env['BUILDERS']['markdown'] = mdBuilder
 
 
-# If using Flake8, F821 should be ignored as 'Variables' and friends come from SCons.
 vars = Variables()
 vars.Add("version", "The version of this build", buildVars.addon_info["addon_version"])
 vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))


### PR DESCRIPTION
This pull  request:
- Imports functions used in Sconstruct explicitly to avoid Linter warnings.
tested with Python 3.7 with SCons 4.0.1 on Windows, Python 2.7 with SCons 3.2.1 (this is last version of SCons to support Python 2)and with Python 3.8 and latest SCons on Arch Linux.
- Adds explanatory comment about  `_` function in buildVars and explains how to use glob expressions to specify add-on source files.