### PR TITLE
Add-on documentation titles

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -25,8 +25,17 @@ import buildVars  # NOQA: E402
 def md2html(source, dest):
 	import markdown
 	lang = os.path.basename(os.path.dirname(source)).replace('_', '-')
+	localeLang = os.path.basename(os.path.dirname(source))
+	try:
+		if sys.version_info.major == 2:
+			_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[localeLang]).ugettext
+		else:
+			_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[localeLang]).gettext
+		summary = _(buildVars.addon_info["addon_summary"])
+	except:
+		summary = buildVars.addon_info["addon_summary"]
 	title = "{addonSummary} {addonVersion}".format(
-		addonSummary=buildVars.addon_info["addon_summary"], addonVersion=buildVars.addon_info["addon_version"]
+		addonSummary=summary, addonVersion=buildVars.addon_info["addon_version"]
 	)
 	headerDic = {
 		"[[!meta title=\"": "# ",


### PR DESCRIPTION
This contribution has been made by @paulber19, who isn't familiar with pull requests yet. It fixes a but which caused the generated HTML documents to display their title always in english (or, more recently, in the base language). Now, titles are properly translated using the localized version of buildVars.addon_summary.