### PR TITLE
Critical bugfix for scons clean and base language

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -229,4 +229,4 @@ env.Depends(manifest, "buildVars.py")
 
 env.Depends(addon, manifest)
 env.Default(addon)
-env.Clean(addon, ['.sconsign.dblite', 'addon/doc/en/'])
+env.Clean(addon, ['.sconsign.dblite', 'addon/doc/' + buildVars.baseLanguage + '/'])


### PR DESCRIPTION
This is a follow-up for a previous pull request where baseLanguage variable was added. It fixes a bug which caused scons to remove always the english documentation regardless of the base language when `scons clean` command was used. Now, the directory with the base language documentation is removed instead.