### PR TITLE
Support GH Actions

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -1,0 +1,63 @@
+name: build addon
+
+on:
+  push:
+    tags: ["*"]
+    branches: [ main , master ]
+
+  pull_request:
+    branches: [ main, master ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - run: echo -e "pre-commit\nscons\nmarkdown">requirements.txt
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install -r requirements.txt
+        sudo apt-get update  -y
+        sudo apt-get install -y gettext
+
+    - name: Code checks
+      run: export SKIP=no-commit-to-branch; pre-commit run --all
+
+    - name: building addon
+      run: scons
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: packaged_addon
+        path: ./*.nvda-addon
+
+  upload_release:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    needs: ["build"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: download releases files
+      uses: actions/download-artifact@v3
+    - name: Display structure of downloaded files
+      run: ls -R
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: packaged_addon/*.nvda-addon
+        fail_on_unmatched_files: true
+        prerelease: ${{ contains(github.ref, '-') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-yaml

--- a/readme.md
+++ b/readme.md
@@ -8,12 +8,24 @@ Copyright (C) 2012-2022 NVDA Add-on team contributors.
 
 This package is distributed under the terms of the GNU General Public License, version 2 or later. Please see the file COPYING.txt for further details.
 
+
+
+[alekssamos](https://github.com/alekssamos/) added automatic package of add-ons through Github Actions.
+
+For details about Github Actions  please see the [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions).
+
+Copyright (C) 2022 alekssamos
+
+
 ## Features
 
 This template provides the following features you can use during NVDA add-on development and packaging:
 
 * Automatic add-on package creation, with naming and version loaded from a centralized build variables file (buildVars.py) or command-line interface.
 	* See packaging section for details on using command-line switches when packaging add-ons with custom version information.
+	* This process will happen automatically when you commit to the main branch, when receiving a pull request, and there is also the possibility of manual launch.
+	* If you have created a tag (E.G.: `git tag v1.0 && git push --tag`), then a release will be automatically created and the add-on file will be uploaded as an asset.
+	* Otherwise, with normal commits or with manual startup, you can download the artifacts from the Actions page of your repository.
 * Manifest file creation using a template (manifest.ini.tpl). Build variables are replaced on this template. See below for add-on manifest specification.
 * Compilation of gettext mo files before distribution, when needed.
 	* To generate a gettext pot file, please run scons pot. A **addon-name.pot** file will be created with all gettext messages for your add-on. You need to check the buildVars.i18nSources variable to comply with your requirements.


### PR DESCRIPTION
Automatic build of the add-on and loading of the nvda-addon file as a release when creating a tag.