### PR TITLE
Add workspace configuration for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+		"redhat.vscode-yaml"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+    "editor.accessibilitySupport": "on",
+    "python.linting.enabled": true,
+    "python.linting.maxNumberOfProblems": 10000,
+    "python.linting.flake8Args": [
+        "--config=flake8.ini"
+    ],
+    "python.linting.flake8Enabled": true,
+    "python.linting.pylintEnabled": false,
+    "python.autoComplete.extraPaths": [
+        "../nvda/source",
+        "../nvda/miscDeps/python"
+        ],	
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "editor.insertSpaces": false,
+    "python.analysis.diagnosticSeverityOverrides": {
+        "reportUndefinedVariable": "none"
+    },
+    "python.analysis.extraPaths": [
+        "../nvda/source",
+        "../nvda/miscDeps/python"
+    ],
+    "python.defaultInterpreterPath": "../nvda/.venv/scripts/python.exe"
+}

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,10 @@ This template provides the following features you can use during NVDA add-on dev
 In addition, this template includes configuration files for the following tools for use in add-on development and testing (see "additional tools" section for details):
 
 * Flake8 (flake8.ini): a base configuration file for Flake8 linting tool based on NVDA's own Flake8 configuration file.
+* Configuration for VS Code. It requires NVDA`s repo at the same level that add-on repos, with prepared source code (`scons source`).
+	* Press `control+shift+m`after saving a file to search for problems.
+	* Use arrow and tab keys for the autocompletion feature.
+	* Press `control+shift+p`to open the commands palette and search for recommended extensions to install or check if they are installed.
 
 ## Requirements
 


### PR DESCRIPTION
This adds a workspace configuration for authors using VS Code to develop add-ons. Based on [configuration workspace recommended for NVDA](https://github.com/nvaccess/vscode-nvda).

## Features

- Enables accessibility support.
- Ability to autocomplete and analyze code considering NVDA submodules. Requires NVDA's repo with prepared source code in the same root folder than add-on repo.
- When saving a file, a final new line is added to it, and extra new lines are trimmed from the end.
- Indentation uses tabs by default.
- Linting with flake8, using the configuration file of the add-on template (flake8.ini).
- Python interpreter is set to `../nvda/.venv/scripts/python.exe, so that wx (and other packages) can be recognized and suggestedinautocompletion.
- Python, Pylance and extensions for .yaml files can be searched in the recommended extensions for the workspace, to make easy to install them if they are not present.
- undefined variables rule has been disabled to prevent that Pylance shows underscore (_), needed for the translation support, as a problem when pressing `control+shift+m`. flake8 will shows as a problem when other undefined names are encountered.

cc: @Josephsl
