### PR TITLE
Some proposed improvements to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ This template provides the following features you can use during NVDA add-on dev
 * Automatic add-on package creation, with naming and version loaded from a centralized build variables file (buildVars.py) or command-line interface.
 	* See packaging section for details on using command-line switches when packaging add-ons with custom version information.
 	* This process will happen automatically when receiving a pull request, and there is also the possibility of manual launch.
-	* To let the workflow run automatically when pushing to main or master (development) branch, remove the comment for branches line in GitHub Actions (.github/workflow/build_addon.yml).
+	* To let the workflow run automatically when pushing to main or master (development) branch, remove the comment for branches line in GitHub Actions (`.github/workflows/build_addon.yml`).
 	* If you have created a tag (E.G.: `git tag v1.0 && git push --tag`), then a release will be automatically created and the add-on file will be uploaded as an asset.
 	* Otherwise, with normal commits or with manual startup, you can download the artifacts from the Actions page of your repository.
 * Manifest file creation using a template (manifest.ini.tpl). Build variables are replaced on this template. See below for add-on manifest specification.

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,8 @@ You need the following software to use this code for your NVDA add-on developmen
 * GNU Gettext tools, if you want to have localization support for your add-on - Recommended. Any Linux distro or cygwin have those installed. You can find windows builds [here](https://gnuwin32.sourceforge.net/downlinks/gettext.php).
 * Markdown 3.3.0 or later, if you want to convert documentation files to HTML documents. You can install it via PIP.
 
+Note, that you may not need these tools in a local build environment, if you are using [Appveyor](https://appveyor.com/) or [GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions), to build and package your add-ons.
+
 ## Usage
 
 ### To create a new NVDA add-on using this template:

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,10 @@ sconstruct
 ```
 .github
 ```
+and file:
+```
+.pre-commit-config.yaml
+```
 4. Create an `addon` folder inside your new folder. You will put your code in the usual folders for NVDA extensions, under the `addon` folder. For instance: `globalPlugins`, `synthDrivers`, etc.
 5. In the `buildVars.py` file, change variable `addon_info` with your add-on's information (name, summary, description, version, author, url, source url, license, and license URL).
 6. Gettext translations must be placed into `addon\locale\<lang>/LC_MESSAGES\nvda.po`.

--- a/readme.md
+++ b/readme.md
@@ -74,10 +74,9 @@ sconstruct
 ```
 .github
 ```
-4. Create an **addon** folder inside your new folder. Inside the **addon* folder, create needed folders for the add-on modules (e.g. appModules, synthDrivers, etc.). An add-on may have one or more module folders.
+4. Create an `addon` folder inside your new folder. You will put your code in the usual folders for NVDA extensions, under the `addon` folder. For instance: `globalPlugins`, `synthDrivers`, etc.
 5. In the `buildVars.py` file, change variable `addon_info` with your add-on's information (name, summary, description, version, author, url, source url, license, and license URL).
-6. Put your code in the usual folders for NVDA extension, under the **addon** folder. For instance: globalPlugins, synthDrivers, etc.
-7. Gettext translations must be placed into addon\locale\<lang>/LC_MESSAGES\nvda.po. 
+6. Gettext translations must be placed into `addon\locale\<lang>/LC_MESSAGES\nvda.po`.
 
 #### Add-on manifest specification
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ This template provides the following features you can use during NVDA add-on dev
 	* Otherwise, with normal commits or with manual startup, you can download the artifacts from the Actions page of your repository.
 * Manifest file creation using a template (manifest.ini.tpl). Build variables are replaced on this template. See below for add-on manifest specification.
 * Compilation of gettext mo files before distribution, when needed.
-	* To generate a gettext pot file, please run scons pot. A **addon-name.pot** file will be created with all gettext messages for your add-on. You need to check the buildVars.i18nSources variable to comply with your requirements.
+	* To generate a gettext pot file, please run scons pot. An **addon-name.pot** file will be created with all gettext messages for your add-on. You need to check the `buildVars.i18nSources` variable to comply with your requirements.
 * Automatic generation of manifest localization files directly from gettext po files. Please make sure buildVars.py is included in i18nFiles.
 * Automatic generation of HTML documents from markdown (.md) files, to manage documentation in different languages.
 * Automatic generation of entries for NV Access add-on store (json format).
@@ -38,7 +38,7 @@ This template provides the following features you can use during NVDA add-on dev
 In addition, this template includes configuration files for the following tools for use in add-on development and testing (see "additional tools" section for details):
 
 * Flake8 (flake8.ini): a base configuration file for Flake8 linting tool based on NVDA's own Flake8 configuration file.
-* Configuration for VS Code. It requires NVDA`s repo at the same level that add-on repos, with prepared source code (`scons source`).
+* Configuration for VS Code. It requires NVDA's repo at the same level as the add-on repo, with prepared source code (`scons source`).
 	* Press `control+shift+m`after saving a file to search for problems.
 	* Use arrow and tab keys for the autocompletion feature.
 	* Press `control+shift+p`to open the commands palette and search for recommended extensions to install or check if they are installed.

--- a/readme.md
+++ b/readme.md
@@ -57,11 +57,27 @@ You need the following software to use this code for your NVDA add-on developmen
 ### To create a new NVDA add-on using this template:
 
 1. Create an empty folder to hold the files for your add-on.
-2. Copy the **site_scons** folder, and the following files, into your new empty folder: **buildVars.py**, **manifest.ini.tpl**, **manifest-translated.ini.tpl**, **sconstruct**, **.gitignore**, and **.gitattributes**
-3. Create an **addon** folder inside your new folder. Inside the **addon* folder, create needed folders for the add-on modules (e.g. appModules, synthDrivers, etc.). An add-on may have one or more module folders.
-4. In the **buildVars.py** file, change variable **addon_info** with your add-on's information (name, summary, description, version, author, url, source url, license, and license URL).
-5. Put your code in the usual folders for NVDA extension, under the **addon** folder. For instance: globalPlugins, synthDrivers, etc.
-6. Gettext translations must be placed into addon\locale\<lang>/LC_MESSAGES\nvda.po. 
+2. Copy the folder:
+```
+site_scons
+```
+and the following files, into your new empty folder:
+```
+buildVars.py
+manifest.ini.tpl
+manifest-translated.ini.tpl
+sconstruct
+.gitignore
+.gitattributes
+```
+3. If you intend to use the provided GitHub workflow, also copy the folder:
+```
+.github
+```
+4. Create an **addon** folder inside your new folder. Inside the **addon* folder, create needed folders for the add-on modules (e.g. appModules, synthDrivers, etc.). An add-on may have one or more module folders.
+5. In the `buildVars.py` file, change variable `addon_info` with your add-on's information (name, summary, description, version, author, url, source url, license, and license URL).
+6. Put your code in the usual folders for NVDA extension, under the **addon** folder. For instance: globalPlugins, synthDrivers, etc.
+7. Gettext translations must be placed into addon\locale\<lang>/LC_MESSAGES\nvda.po. 
 
 #### Add-on manifest specification
 

--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,7 @@ and file:
 .pre-commit-config.yaml
 ```
 4. Create an `addon` folder inside your new folder. You will put your code in the usual folders for NVDA extensions, under the `addon` folder. For instance: `globalPlugins`, `synthDrivers`, etc.
-5. In the `buildVars.py` file, change variable `addon_info` with your add-on's information (name, summary, description, version, author, url, source url, license, and license URL).
+5. In the `buildVars.py` file, change variable `addon_info` with your add-on's information (name, summary, description, version, author, url, source url, license, and license URL). Also, be sure to carefully set the paths contained in the other variables in that file.
 6. Gettext translations must be placed into `addon\locale\<lang>/LC_MESSAGES\nvda.po`.
 
 #### Add-on manifest specification

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ This template provides the following features you can use during NVDA add-on dev
 	* Otherwise, with normal commits or with manual startup, you can download the artifacts from the Actions page of your repository.
 * Manifest file creation using a template (manifest.ini.tpl). Build variables are replaced on this template. See below for add-on manifest specification.
 * Compilation of gettext mo files before distribution, when needed.
-	* To generate a gettext pot file, please run scons pot. An **addon-name.pot** file will be created with all gettext messages for your add-on. You need to check the `buildVars.i18nSources` variable to comply with your requirements.
+	* To generate a gettext pot file, please run `scons pot`. An `addon-name.pot` file will be created with all gettext messages for your add-on. You need to check the `buildVars.i18nSources` variable to comply with your requirements.
 * Automatic generation of manifest localization files directly from gettext po files. Please make sure buildVars.py is included in i18nFiles.
 * Automatic generation of HTML documents from markdown (.md) files, to manage documentation in different languages.
 * Automatic generation of entries for NV Access add-on store (json format).
@@ -82,7 +82,7 @@ sconstruct
 
 #### Add-on manifest specification
 
-An add-on manifest generated manually or via **buildVars.py** must include the following information:
+An add-on manifest generated manually or via `buildVars.py` must include the following information:
 
 * Name (string): a unique identifier for the add-on. It must use camel case (e.g. someModule). This is also used as part of add-on store to identify the add-on uniquely.
 * Summary (string): name as shown on NVDA's Add-ons Manager.
@@ -103,13 +103,13 @@ In addition, the following information must be filled out (not used in the manif
 
 ### To manage documentation files for your addon:
 
-1. Copy the **readme.md** file for your add-on to the first created folder, where you copied **buildVars.py**. You can also copy **style.css** to improve the presentation of HTML documents.
-2. Documentation files (named **readme.md**) must be placed into addon\doc\<lang>/.
+1. Copy the `readme.md` file for your add-on to the first created folder, where you copied `buildVars.py`. You can also copy `style.css` to improve the presentation of HTML documents.
+2. Documentation files (named `readme.md`) must be placed into `addon\doc\<lang>/`.
 
 ### To package the add-on for distribution:
 
-1. Open a command line, change to the folder that has the **sconstruct** file (usually the root of your add-on development folder) and run the **scons** command. The created add-on, if there were no errors, is placed in the current directory.
-2. You can further customize variables in the **buildVars.py** file.
+1. Open a command line, change to the folder that has the `sconstruct` file (usually the root of your add-on development folder) and run the `scons` command. The created add-on, if there were no errors, is placed in the current directory.
+2. You can further customize variables in the `buildVars.py` file.
 3. You can also customize version and update channel information from command line by passing the following switches when running scons:
 	* version: add-on version string.
 	* versionNumber: add-on version number of the form major.minor.patch (all integers)


### PR DESCRIPTION
The following commits present some proposed improvements (in my opinion) to the readme.

1. Wherever bolding markdown was used to designate file names, folder names, or the like, I have changed these to code markers. In the future, it may be useful to also add quotes to some of them, but I didn't want to do that here.
2. Added some code markers around file/folder names which lacked any kind of distinctive markdown.
3. Added a note to the end of the Requirements section, about using cloud based build environments instead of local building.
4. In section "To create a new add-on using this template": inserted a new step 3, instructing what to copy for workflows usage. Also separated the files/folders to copy into blocks of code markers, to make them easier to copy and paste.
5. Also in section "To create a new add-on using this template": I merged steps 4 and 6, which were redundant. Note that before the previous change, these were steps 3 and 5.
6. Corrected the path of the workflows folder.
7. Updated the copyright, and made a couple minor grammar/punctuation corrections.
