### PR TITLE
Ignore JSON file generated for the add-on store.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ addon/doc/en/
 *.py[co]
 *.nvda-addon
 .sconsign.dblite
+/[0-9]*.[0-9]*.[0-9]*.json


### PR DESCRIPTION
### Context
The generation of a JSON file for the add-on store has recently been included in the template.

### Issue
This new JSON generated file is not ignored by git, i.e. it appears when executing "git status".

### Solution
Ignore such JSON files.

Since the add-ons may use JSON files for other purposes, the pattern iused in `.gitignore` garantees that a JSON file is ignored only if it meets the following conditions:
* only in the root folder, not in subfolders
* only file names with 3 parts separated by dots
* each part begins with a number but can have more characters

### Known issue
Some files whose patterns do not correspond to the add-on store versioning scheme may be ignored as well, e.g.: "1foo.2bar.3baz.json". I do not know a way to use quantificaters on a specific class of characters ([0-9]) as it is done in regexps. The ideal would be that each part uses one ore more digit instead.

Such corner cases would be very rare however and I do not know any real-life situation where such files are used in NVDA eco-system.

