### PR TITLE
Fixed title translation in documentation file

### DIFF
--- a/sconstruct
+++ b/sconstruct
@@ -299,7 +299,7 @@ for file in pythonFiles:
 createAddonHelp("addon")
 for mdFile in env.Glob(os.path.join('addon', 'doc', '*', '*.md')):
 	htmlFile = env.markdown(mdFile)
-	env.Depends(htmlFile, mdFile)
+	env.Depends(htmlFile, [mdFile, moFile])
 	env.Depends(addon, htmlFile)
 
 # Pot target


### PR DESCRIPTION
### This PR provides the following fix

Fixed title translation in documentation file when using scons command.

Changed line 302 of the sconstruct file from:

-	env.Depends(htmlFile, mdFile)

To:

-	env.Depends(htmlFile, [mdFile, moFile])

The generation of html files must also depend on mo files.

Uncompiled po files provide no translations.

Without this correction, the titles of the documentations are never translated.