### PR TITLE
VS Code config: Add functions used for translation to the list of recognized build-in names.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,9 +14,7 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "editor.insertSpaces": false,
-    "python.analysis.diagnosticSeverityOverrides": {
-        "reportUndefinedVariable": "none"
-    },
+    "python.analysis.stubPath": "${workspaceFolder}/.vscode/typings",
     "python.analysis.extraPaths": [
         "../nvda/source",
         "../nvda/miscDeps/python"

--- a/.vscode/typings/__builtins__.pyi
+++ b/.vscode/typings/__builtins__.pyi
@@ -1,0 +1,6 @@
+def _(msg: str) -> str:
+	...
+
+
+def pgettext(context: str, message: str) -> str:
+	...


### PR DESCRIPTION
Pr #24 added configuration for Visual Studio Code to the template. While it works well for the most part, the functions used for translation (notable `_`, shorthand for gettext cause warnings about undefined names. @nvdaes  fixed this by disabling reporting of undefined variables, however this does not work at least on my side, and honestly is more of a work around than a proper fix.
This pull requests adds additional names to the list of build-ins recognized by Pyright, and removes the work around from the main settings file.
The fact that warnings are no longer shown aside, this also adds proper type annotations to these functions, so that we have working Intellisense in the editor.