### PR TITLE
Fixed the error that the NVDA Python virtual environment could not be…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
     "python.autoComplete.extraPaths": [
         "../nvda/source",
         "../nvda/miscDeps/python"
-        ],	
+    ],
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "editor.insertSpaces": false,
@@ -19,5 +19,5 @@
         "../nvda/source",
         "../nvda/miscDeps/python"
     ],
-    "python.defaultInterpreterPath": "../nvda/.venv/scripts/python.exe"
+    "python.defaultInterpreterPath": "${workspaceFolder}/../nvda/.venv/scripts/python.exe"
 }


### PR DESCRIPTION
VS Code Python extension error log:

```
2023-09-22 17:59:12.201 [warning] Identifier for virt-virtualenv failed to identify ..\nvda\.venv\scripts\python.exe [Error: ENOENT: no such file or directory, scandir 'C:\Users\hwf1324\AppData\Local\Programs\nvda\.venv\scripts'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'scandir',
  path: 'C:\\Users\\hwf1324\\AppData\\Local\\Programs\\nvda\\.venv\\scripts'
}
``` 