### PR TITLE
Feature migration to python flake8 extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,8 @@
 	"recommendations": [
 		"ms-python.python",
 		"ms-python.vscode-pylance",
-		"redhat.vscode-yaml"
+		"redhat.vscode-yaml",
+		"ms-python.flake8" // flake8 extension version <= v2023.4.0
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,7 @@
 		"ms-python.python",
 		"ms-python.vscode-pylance",
 		"redhat.vscode-yaml",
-		"ms-python.flake8" // flake8 extension version <= v2023.4.0
+		"ms-python.flake8"
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
     "python.autoComplete.extraPaths": [
         "../nvda/source",
         "../nvda/miscDeps/python"
-        ],	
+    ],
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "editor.insertSpaces": false,
@@ -19,5 +19,5 @@
         "../nvda/source",
         "../nvda/miscDeps/python"
     ],
-    "python.defaultInterpreterPath": "../nvda/.venv/scripts/python.exe"
+    "python.defaultInterpreterPath": "${workspaceFolder}/../nvda/.venv/scripts/python.exe"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,9 @@
 {
     "editor.accessibilitySupport": "on",
-    "python.linting.enabled": true,
-    "python.linting.maxNumberOfProblems": 10000,
-    "python.linting.flake8Args": [
+    "flake8.args": [
         "--config=flake8.ini"
     ],
-    "python.linting.flake8Enabled": true,
-    "python.linting.pylintEnabled": false,
+    "flake8.importStrategy": "fromEnvironment",
     "python.autoComplete.extraPaths": [
         "../nvda/source",
         "../nvda/miscDeps/python"


### PR DESCRIPTION
See: https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions

Of course, before NVDA has upgraded Python, this PR still needs to be considered.