### PR TITLE
Changelog support by default

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -55,10 +55,13 @@ jobs:
       uses: actions/download-artifact@v3
     - name: Display structure of downloaded files
       run: ls -R
+    - name: Calculate sha256
+      run: sha256sum packaged_addon/*.nvda-addon >> changelog.md
 
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
         files: packaged_addon/*.nvda-addon
+        body_path: changelog.md
         fail_on_unmatched_files: true
         prerelease: ${{ contains(github.ref, '-') }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+Use this file to explain what has changed in your add-on since the previous release. This will be included automatically in the release description when used with GitHub actions.
+
+Don't modify the following line, unless you also remove SHA256 sum calculation from the workflow. This line must be the last one in the file.
+
+SHA256: 


### PR DESCRIPTION
Include a changelog file which will be part of the release body when GitHub workflow is triggered. Add-on SHA256 sum will always be printed at the end of the file.
Currently, most add-on developers don't explain what has changed between releases. A few of them edit the release to add a description, but it's too late to receive that description as part of the release notification. Others prefer automatic release notes, which point to a comparison page with a list of commits.
This pr adds the ability to summarise add-on changes in a file using Markdown, commit that file and have a changelog by default as part of the release body, saving extra time for developers.