### PR TITLE
Generate automatically a template for translators

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -38,12 +38,14 @@ jobs:
       run: export SKIP=no-commit-to-branch; pre-commit run --all
 
     - name: building addon
-      run: scons
+      run: scons && scons pot
 
     - uses: actions/upload-artifact@v3
       with:
         name: packaged_addon
-        path: ./*.nvda-addon
+        path: |
+          ./*.nvda-addon
+          ./*.pot
 
   upload_release:
     runs-on: ubuntu-latest
@@ -59,6 +61,8 @@ jobs:
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: packaged_addon/*.nvda-addon
+        files: |
+          packaged_addon/*.nvda-addon
+          packaged_addon/*.pot
         fail_on_unmatched_files: true
         prerelease: ${{ contains(github.ref, '-') }}


### PR DESCRIPTION
This pull request updates the included workflow to generate a pot file during the build process and attach it to the release assets automatically. Pot files are useful for translators and add-on authors who don't use the NV Access translation system.