### PR TITLE
Update changelog.md to address automatic formatting on IDE saves.

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -58,7 +58,9 @@ jobs:
     - name: Display structure of downloaded files
       run: ls -R
     - name: Calculate sha256
-      run: sha256sum packaged_addon/*.nvda-addon >> changelog.md
+      run: |
+        echo -e "\nSHA256: " >> changelog.md
+        sha256sum packaged_addon/*.nvda-addon >> changelog.md
 
     - name: Release
       uses: softprops/action-gh-release@v2

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,1 @@
 Use this file to explain what has changed in your add-on since the previous release. This will be included automatically in the release description when used with GitHub actions.
-
-Don't modify the following line, unless you also remove SHA256 sum calculation from the workflow. This line must be the last one in the file.
-
-SHA256: 


### PR DESCRIPTION
When saving changelog.md in the IDE, auto-formatting fixes end-of-line spaces and the last new line.

The ‘SHA256:’ hint will be added by GitHub Actions.