### PR TITLE
Enable write permission when creating releases

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -51,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs: ["build"]
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
     - name: download releases files


### PR DESCRIPTION
According to the [action-gh-release documentation](https://github.com/softprops/action-gh-release#permissions), write permission is required for contents.

Without this, I get the error "Resource not accessible by integration".
