### PR TITLE
fix: resolve file upload failure

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -65,11 +65,11 @@ jobs:
         sha256sum packaged_addon/*.nvda-addon >> changelog.md
 
     - name: Release
-      uses: softprops/action-gh-release@v2
+      uses: ncipollo/release-action@v1
       with:
-        files: |
-          packaged_addon/*.nvda-addon
-          packaged_addon/*.pot
-        body_path: changelog.md
-        fail_on_unmatched_files: true
+        artifacts: |
+          packaged_addon/*.nvda-addon,packaged_addon/*.pot
+        bodyFile: changelog.md
+        artifactErrorsFailBuild: true
         prerelease: ${{ contains(github.ref, '-') }}
+        


### PR DESCRIPTION
fix: resolve file upload failure in GitHub Actions release step by replacing softprops/action-gh-release@v2 with ncipollo/release-action@v1