### PR TITLE
Modernization of the code base

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -9,7 +9,7 @@
 # Gettext recognizes only strings given as parameters to the `_` function.
 # To avoid initializing translations in this module we simply roll our own "fake" `_` function
 # which returns whatever is given to it as an argument.
-def _(arg):
+def _(arg: str) -> str:
 	return arg
 
 

--- a/buildVars.py
+++ b/buildVars.py
@@ -1,7 +1,7 @@
 # Build customizations
 # Change this file instead of sconstruct or manifest files, whenever possible.
 
-from typing import TypedDict
+from site_scons.site_tools.NVDATool.typings import AddonInfo
 
 # Since some strings in `addon_info` are translatable,
 # we need to include them in the .po files.
@@ -11,22 +11,6 @@ from typing import TypedDict
 def _(arg: str) -> str:
 	return arg
 
-
-# A typed dictionary for storing meta information about add-on.
-class AddonInfo(TypedDict):
-	addon_name: str
-	addon_summary: str
-	addon_description: str
-	addon_version: str
-	addon_author: str
-	addon_url: str|None
-	addon_sourceURL: str|None
-	addon_docFileName: str
-	addon_minimumNVDAVersion: str|None
-	addon_lastTestedNVDAVersion: str|None
-	addon_updateChannel: str|None
-	addon_license: str|None
-	addon_licenseURL: str|None
 
 # Add-on information variables
 addon_info: AddonInfo = {

--- a/buildVars.py
+++ b/buildVars.py
@@ -1,5 +1,3 @@
-# -*- coding: UTF-8 -*-
-
 # Build customizations
 # Change this file instead of sconstruct or manifest files, whenever possible.
 
@@ -57,29 +55,29 @@ It can span multiple lines."""),
 # pythonSources = ["addon/globalPlugins/*.py"]
 # For more information on SCons Glob expressions please take a look at:
 # https://scons.org/doc/production/HTML/scons-user/apd.html
-pythonSources = []
+pythonSources: list[str] = []
 
 # Files that contain strings for translation. Usually your python sources
-i18nSources = pythonSources + ["buildVars.py"]
+i18nSources: list[str] = pythonSources + ["buildVars.py"]
 
 # Files that will be ignored when building the nvda-addon file
 # Paths are relative to the addon directory, not to the root directory of your addon sources.
 # You can either list every file (using ""/") as a path separator,
 # or use glob expressions.
-excludedFiles = []
+excludedFiles: list[str] = []
 
 # Base language for the NVDA add-on
 # If your add-on is written in a language other than english, modify this variable.
 # For example, set baseLanguage to "es" if your add-on is primarily written in spanish.
 # You must also edit .gitignore file to specify base language files to be ignored.
-baseLanguage = "en"
+baseLanguage: str = "en"
 
 # Markdown extensions for add-on documentation
 # Most add-ons do not require additional Markdown extensions.
 # If you need to add support for markup such as tables, fill out the below list.
 # Extensions string must be of the form "markdown.extensions.extensionName"
 # e.g. "markdown.extensions.tables" to add tables.
-markdownExtensions = []
+markdownExtensions: list[str] = []
 
 # Custom braille translation tables
 # If your add-on includes custom braille tables (most will not), fill out this dictionary.

--- a/buildVars.py
+++ b/buildVars.py
@@ -1,7 +1,7 @@
 # Build customizations
 # Change this file instead of sconstruct or manifest files, whenever possible.
 
-from site_scons.site_tools.NVDATool.typings import AddonInfo
+from site_scons.site_tools.NVDATool.typings import AddonInfo, BrailleTables, SymbolDictionaries
 
 # Since some strings in `addon_info` are translatable,
 # we need to include them in the .po files.
@@ -88,7 +88,7 @@ markdownExtensions: list[str] = []
 # contracted (contracted (True) or uncontracted (False) braille code),
 # output (shown in output table list),
 # input (shown in input table list).
-brailleTables: dict[str, dict[str, str]] = {}
+brailleTables: BrailleTables = {}
 
 # Custom speech symbol dictionaries
 # Symbol dictionary files reside in the locale folder, e.g. `locale\en`, and are named `symbols-<name>.dic`.
@@ -97,4 +97,4 @@ brailleTables: dict[str, dict[str, str]] = {}
 # with keys inside recording the following attributes:
 # displayName (name of the speech dictionary shown to users and translatable),
 # mandatory (True when always enabled, False when not.
-symbolDictionaries: dict[str, dict[str, str]] = {}
+symbolDictionaries: SymbolDictionaries = {}

--- a/buildVars.py
+++ b/buildVars.py
@@ -1,6 +1,7 @@
 # Build customizations
 # Change this file instead of sconstruct or manifest files, whenever possible.
 
+from typing import TypedDict
 
 # Since some strings in `addon_info` are translatable,
 # we need to include them in the .po files.
@@ -11,8 +12,24 @@ def _(arg: str) -> str:
 	return arg
 
 
+# A typed dictionary for storing meta information about add-on.
+class AddonInfo(TypedDict):
+	addon_name: str
+	addon_summary: str
+	addon_description: str
+	addon_version: str
+	addon_author: str
+	addon_url: str|None
+	addon_sourceURL: str|None
+	addon_docFileName: str
+	addon_minimumNVDAVersion: str|None
+	addon_lastTestedNVDAVersion: str|None
+	addon_updateChannel: str|None
+	addon_license: str|None
+	addon_licenseURL: str|None
+
 # Add-on information variables
-addon_info = {
+addon_info: AddonInfo = {
 	# add-on Name/identifier, internal for NVDA
 	"addon_name": "addonTemplate",
 	# Add-on summary/title, usually the user visible name of the add-on

--- a/buildVars.py
+++ b/buildVars.py
@@ -6,10 +6,9 @@ from site_scons.site_tools.NVDATool.typings import AddonInfo, BrailleTables, Sym
 # Since some strings in `addon_info` are translatable,
 # we need to include them in the .po files.
 # Gettext recognizes only strings given as parameters to the `_` function.
-# To avoid initializing translations in this module we simply roll our own "fake" `_` function
+# To avoid initializing translations in this module we simply import a "fake" `_` function
 # which returns whatever is given to it as an argument.
-def _(arg: str) -> str:
-	return arg
+from site_scons.site_tools.NVDATool.utils import _
 
 
 # Add-on information variables

--- a/buildVars.py
+++ b/buildVars.py
@@ -104,7 +104,7 @@ markdownExtensions: list[str] = []
 # contracted (contracted (True) or uncontracted (False) braille code),
 # output (shown in output table list),
 # input (shown in input table list).
-brailleTables = {}
+brailleTables: dict[str, dict[str, str]] = {}
 
 # Custom speech symbol dictionaries
 # Symbol dictionary files reside in the locale folder, e.g. `locale\en`, and are named `symbols-<name>.dic`.
@@ -113,4 +113,4 @@ brailleTables = {}
 # with keys inside recording the following attributes:
 # displayName (name of the speech dictionary shown to users and translatable),
 # mandatory (True when always enabled, False when not.
-symbolDictionaries = {}
+symbolDictionaries: dict[str, dict[str, str]] = {}

--- a/buildVars.py
+++ b/buildVars.py
@@ -12,40 +12,40 @@ from site_scons.site_tools.NVDATool.utils import _
 
 
 # Add-on information variables
-addon_info: AddonInfo = {
+addon_info = AddonInfo(
 	# add-on Name/identifier, internal for NVDA
-	"addon_name": "addonTemplate",
+	addon_name="addonTemplate",
 	# Add-on summary/title, usually the user visible name of the add-on
 	# Translators: Summary/title for this add-on
 	# to be shown on installation and add-on information found in add-on store
-	"addon_summary": _("Add-on user visible name"),
+	addon_summary=_("Add-on user visible name"),
 	# Add-on description
 	# Translators: Long description to be shown for this add-on on add-on information from add-on store
-	"addon_description": _("""Description for the add-on.
+	addon_description=_("""Description for the add-on.
 It can span multiple lines."""),
 	# version
-	"addon_version": "x.y",
+	addon_version="x.y",
 	# Author(s)
-	"addon_author": "name <name@domain.com>",
+	addon_author="name <name@domain.com>",
 	# URL for the add-on documentation support
-	"addon_url": None,
+	addon_url=None,
 	# URL for the add-on repository where the source code can be found
-	"addon_sourceURL": None,
+	addon_sourceURL=None,
 	# Documentation file name
-	"addon_docFileName": "readme.html",
+	addon_docFileName="readme.html",
 	# Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)
-	"addon_minimumNVDAVersion": None,
+	addon_minimumNVDAVersion=None,
 	# Last NVDA version supported/tested (e.g. "2024.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": None,
+	addon_lastTestedNVDAVersion=None,
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!
-	"addon_updateChannel": None,
+	addon_updateChannel=None,
 	# Add-on license such as GPL 2
-	"addon_license": None,
+	addon_license=None,
 	# URL for the license document the ad-on is licensed under
-	"addon_licenseURL": None,
-}
+	addon_licenseURL=None,
+)
 
 # Define the python files that are the sources of your add-on.
 # You can either list every file (using ""/") as a path separator,

--- a/sconstruct
+++ b/sconstruct
@@ -46,8 +46,11 @@ def validateVersionNumber(key: str, val: str, _):
 
 
 def addonTool(env: Environment):
+	env.SetDefault(excludePatterns=tuple())
 	action = env.Action(
-		lambda target, source, env: createAddonBundleFromPath(source[0].abspath, target[0].abspath) and None,
+		lambda target, source, env: createAddonBundleFromPath(
+			source[0].abspath, target[0].abspath, env["excludePatterns"]
+		) and None,
 		lambda target, source, env: f"Generating Addon {target[0]}",
 	)
 	env["BUILDERS"]["NVDAAddon"] = Builder(
@@ -85,7 +88,7 @@ def matchesNoPatterns(path: Path, patterns: Iterable[str]) -> bool:
 	return not any((path.match(pattern) for pattern in patterns))
 
 
-def createAddonBundleFromPath(path: str|Path, dest: str):
+def createAddonBundleFromPath(path: str|Path, dest: str, excludePatterns: Iterable[str]):
 	"""Creates a bundle from a directory that contains an addon manifest file."""
 	if isinstance(path, str):
 		path = Path(path)
@@ -95,7 +98,7 @@ def createAddonBundleFromPath(path: str|Path, dest: str):
 			if p.is_dir():
 				continue
 			pathInBundle = p.relative_to(basedir)
-			if matchesNoPatterns(pathInBundle, buildVars.excludedFiles):
+			if matchesNoPatterns(pathInBundle, excludePatterns):
 				z.write(p, pathInBundle)
 	return dest
 
@@ -200,7 +203,7 @@ env["BUILDERS"]["NVDATranslatedManifest"] = Builder(generator=translatedManifest
 
 
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
-addon = env.NVDAAddon(addonFile, env.Dir(addonDir))
+addon = env.NVDAAddon(addonFile, env.Dir(addonDir), excludePatterns=buildVars.excludedFiles)
 
 langDirs: list[FS.Dir] = [d for d in env.Glob(localeDir/"*/")]
 

--- a/sconstruct
+++ b/sconstruct
@@ -18,6 +18,7 @@ from typing import Final
 # To avoid PyRight `reportUndefinedVariable` errors about them they are imported explicitly.
 # When using other  Scons functions please add them to the line below.
 from SCons.Script import EnsurePythonVersion, Variables, BoolVariable, Environment
+from SCons.Node import FS
 
 # Add-on localization exchange facility and the template requires Python 3.10.
 # For best practice, use Python 3.11 or later to align with NVDA development.
@@ -265,7 +266,7 @@ def generateTranslatedManifest(source, language, out):
 		f.write(result)
 
 
-def expandGlobs(patterns: Iterable[str]) -> list:
+def expandGlobs(patterns: Iterable[str]) -> list[FS.File]:
 	base = Path(".")
 	return [env.File(f) for pattern in patterns for f in base.glob(pattern.lstrip('/'))]
 
@@ -273,10 +274,10 @@ def expandGlobs(patterns: Iterable[str]) -> list:
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
 addon = env.NVDAAddon(addonFile, env.Dir(addonDir))
 
-langDirs = [env.Dir(d) for d in localeDir.glob("*/")]
+langDirs: list[FS.Dir] = [env.Dir(d) for d in localeDir.glob("*/")]
 
 # Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
-moByLang = {}
+moByLang: dict[FS.Dir, FS.File] = {}
 for dir in langDirs:
 	poFile = dir.File(os.path.join("LC_MESSAGES", "nvda.po"))
 	moFile = env.gettextMoFile(poFile)

--- a/sconstruct
+++ b/sconstruct
@@ -45,12 +45,16 @@ def validateVersionNumber(key: str, val: str, _):
 		raise ValueError(f"{key} (major.minor.patch) must be integers")
 
 
-def addonGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
+def addonTool(env: Environment):
 	action = env.Action(
 		lambda target, source, env: createAddonBundleFromPath(source[0].abspath, target[0].abspath) and None,
 		lambda target, source, env: f"Generating Addon {target[0]}",
 	)
-	return action
+	env["BUILDERS"]["NVDAAddon"] = Builder(
+		action=action,
+		suffix=".nvda-addon",
+		src_suffix="/"
+	)
 
 
 def manifestGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
@@ -168,7 +172,7 @@ vars.Add("versionNumber", "Version number of the form major.minor.patch", "0.0.0
 vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
 vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
 
-env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool"])
+env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool", addonTool])
 env.Append(**buildVars.addon_info)
 
 if env["dev"]:
@@ -188,7 +192,6 @@ buildVars.addon_info["addon_version"] = env["addon_version"]
 buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
 
 
-env["BUILDERS"]["NVDAAddon"] = Builder(generator=addonGenerator)
 env["BUILDERS"]["NVDAManifest"] = Builder(generator=manifestGenerator)
 env["BUILDERS"]["NVDATranslatedManifest"] = Builder(generator=translatedManifestGenerator)
 

--- a/sconstruct
+++ b/sconstruct
@@ -165,21 +165,11 @@ def generateManifest(source: str, dest: str):
 	# Add additional manifest sections such as custom braile tables
 	# Custom braille translation tables
 	if hasattr(buildVars, "brailleTables"):
-		manifest_brailleTables = ["\n[brailleTables]"]
-		for table in buildVars.brailleTables.keys():
-			manifest_brailleTables.append(f"[[{table}]]")
-			for key, val in buildVars.brailleTables[table].items():
-				manifest_brailleTables.append(f"{key} = {val}")
-		manifest += "\n".join(manifest_brailleTables) + "\n"
+		manifest += format_nested_section("brailleTables", buildVars.brailleTables)
 
 	# Custom speech symbol dictionaries
 	if hasattr(buildVars, "symbolDictionaries"):
-		manifest_symbolDictionaries = ["\n[symbolDictionaries]"]
-		for dictionary in buildVars.symbolDictionaries.keys():
-			manifest_symbolDictionaries.append(f"[[{dictionary}]]")
-			for key, val in buildVars.symbolDictionaries[dictionary].items():
-				manifest_symbolDictionaries.append(f"{key} = {val}")
-		manifest += "\n".join(manifest_symbolDictionaries) + "\n"
+		manifest += format_nested_section("symbolDictionaries", buildVars.symbolDictionaries)
 
 	with codecs.open(dest, "w", "utf-8") as f:
 		f.write(manifest)

--- a/sconstruct
+++ b/sconstruct
@@ -57,12 +57,16 @@ def addonTool(env: Environment):
 	)
 
 
-def manifestGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
+def manifestTool(env: Environment):
 	action = env.Action(
 		lambda target, source, env: generateManifest(source[0].abspath, target[0].abspath) and None,
 		lambda target, source, env: f"Generating manifest {target[0]}",
 	)
-	return action
+	env["BUILDERS"]["NVDAManifest"] = Builder(
+		action=action,
+		suffix=".ini",
+		src_siffix=".ini.tpl"
+	)
 
 
 def translatedManifestGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
@@ -172,7 +176,7 @@ vars.Add("versionNumber", "Version number of the form major.minor.patch", "0.0.0
 vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
 vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
 
-env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool", addonTool])
+env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool", addonTool, manifestTool])
 env.Append(**buildVars.addon_info)
 
 if env["dev"]:
@@ -192,7 +196,6 @@ buildVars.addon_info["addon_version"] = env["addon_version"]
 buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
 
 
-env["BUILDERS"]["NVDAManifest"] = Builder(generator=manifestGenerator)
 env["BUILDERS"]["NVDATranslatedManifest"] = Builder(generator=translatedManifestGenerator)
 
 

--- a/sconstruct
+++ b/sconstruct
@@ -267,7 +267,7 @@ def expandGlobs(patterns: Iterable[str]) -> list:
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
 addon = env.NVDAAddon(addonFile, env.Dir(addonDir))
 
-langDirs = [f for f in env.Glob(localeDir/"*")]
+langDirs = [env.Dir(d) for d in localeDir.glob("*/")]
 
 # Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
 moByLang = {}

--- a/sconstruct
+++ b/sconstruct
@@ -11,7 +11,7 @@ import zipfile
 import sys
 from pathlib import Path
 from collections.abc import Iterable
-from typing import Final
+from typing import Final, Mapping
 
 # While names imported below are available by default in every SConscript
 # Linters aren't aware about them.
@@ -142,6 +142,18 @@ def createAddonBundleFromPath(path: str|Path, dest: str):
 			if matchesNoPatterns(pathInBundle, buildVars.excludedFiles):
 				z.write(p, pathInBundle)
 	return dest
+
+
+def format_nested_section(
+	section_name: str,
+	data: Mapping[str, Mapping[str, str]]
+) -> str:
+	lines = [f"\n[{section_name}]"]
+	for item_name, inner_dict in data.items():
+		lines.append(f"[[{item_name}]]")
+		for key, val in inner_dict.items():
+			lines.append(f"{key} = {val}")
+	return "\n".join(lines) + "\n"
 
 
 def generateManifest(source: str, dest: str):

--- a/sconstruct
+++ b/sconstruct
@@ -239,7 +239,7 @@ for mdFile in env.Glob(docsDir/"*/*.md"):
 	# Thus, we find the moFile for this language and depend on it if it exists.
 	lang = Path(str(mdFile)).absolute().parent.name
 	moFile = moByLang.get(lang)
-	htmlFile = env.markdown(mdFile, localeDir=localeDir, localeFileName="nvda", mdExtensions=buildVars.markdownExtensions)
+	htmlFile = env.md2html(mdFile, localeDir=localeDir, localeFileName="nvda", mdExtensions=buildVars.markdownExtensions)
 	env.Depends(htmlFile, mdFile)
 	if moFile:
 		env.Depends(htmlFile, moFile)

--- a/sconstruct
+++ b/sconstruct
@@ -10,6 +10,7 @@ import os.path
 import zipfile
 import sys
 from pathlib import Path
+from collections.abc import Iterable
 
 # Add-on localization exchange facility and the template requires Python 3.10.
 # For best practice, use Python 3.11 or later to align with NVDA development.
@@ -173,8 +174,9 @@ def createAddonHelp(dir: str|Path):
 		env.Depends(addon, readmeTarget)
 
 
-def matchesNoPatterns(path: Path, patterns: list[str]) -> bool:
-	return all([not path.match(pattern) for pattern in patterns])
+def matchesNoPatterns(path: Path, patterns: Iterable[str]) -> bool:
+	"""Checks if the path, the first argument, does not match any of the patterns passed as the second argument."""
+	return not any((path.match(pattern) for pattern in patterns))
 
 
 def createAddonBundleFromPath(path: str|Path, dest: str):

--- a/sconstruct
+++ b/sconstruct
@@ -13,6 +13,12 @@ from pathlib import Path
 from collections.abc import Iterable
 from typing import Final
 
+# While names imported below are available by default in every SConscript
+# Linters aren't aware about them.
+# To avoid PyRight `reportUndefinedVariable` errors about them they are imported explicitly.
+# When using other  Scons functions please add them to the line below.
+from SCons.Script import EnsurePythonVersion, Variables, BoolVariable, Environment
+
 # Add-on localization exchange facility and the template requires Python 3.10.
 # For best practice, use Python 3.11 or later to align with NVDA development.
 EnsurePythonVersion(3, 10)

--- a/sconstruct
+++ b/sconstruct
@@ -273,7 +273,7 @@ for dir in langDirs:
 	moByLang[dir] = moFile
 	env.Depends(moFile, poFile)
 	translatedManifest = env.NVDATranslatedManifest(
-		dir.File("manifest.ini"), [moFile, os.path.join("manifest-translated.ini.tpl")]
+		dir.File("manifest.ini"), [moFile, "manifest-translated.ini.tpl"]
 	)
 	env.Depends(translatedManifest, ["buildVars.py"])
 	env.Depends(addon, [translatedManifest, moFile])
@@ -312,7 +312,7 @@ env.Alias("mergePot", mergePot)
 env.Depends(mergePot, i18nFiles)
 
 # Generate Manifest path
-manifest = env.NVDAManifest(os.path.join("addon", "manifest.ini"), os.path.join("manifest.ini.tpl"))
+manifest = env.NVDAManifest(os.path.join("addon", "manifest.ini"), "manifest.ini.tpl")
 # Ensure manifest is rebuilt if buildVars is updated.
 env.Depends(manifest, "buildVars.py")
 

--- a/sconstruct
+++ b/sconstruct
@@ -7,7 +7,6 @@ import codecs
 import gettext
 import os
 import os.path
-import zipfile
 import sys
 from pathlib import Path
 from collections.abc import Iterable
@@ -45,21 +44,6 @@ def validateVersionNumber(key: str, val: str, _):
 		raise ValueError(f"{key} (major.minor.patch) must be integers")
 
 
-def addonTool(env: Environment):
-	env.SetDefault(excludePatterns=tuple())
-	action = env.Action(
-		lambda target, source, env: createAddonBundleFromPath(
-			source[0].abspath, target[0].abspath, env["excludePatterns"]
-		) and None,
-		lambda target, source, env: f"Generating Addon {target[0]}",
-	)
-	env["BUILDERS"]["NVDAAddon"] = Builder(
-		action=action,
-		suffix=".nvda-addon",
-		src_suffix="/"
-	)
-
-
 def manifestTool(env: Environment):
 	action = env.Action(
 		lambda target, source, env: generateManifest(source[0].abspath, target[0].abspath) and None,
@@ -81,26 +65,6 @@ def translatedManifestGenerator(target: list[FS.Entry], source: list[FS.Entry], 
 		lambda target, source, env: f"Generating translated manifest {target[0]}",
 	)
 	return action
-
-
-def matchesNoPatterns(path: Path, patterns: Iterable[str]) -> bool:
-	"""Checks if the path, the first argument, does not match any of the patterns passed as the second argument."""
-	return not any((path.match(pattern) for pattern in patterns))
-
-
-def createAddonBundleFromPath(path: str|Path, dest: str, excludePatterns: Iterable[str]):
-	"""Creates a bundle from a directory that contains an addon manifest file."""
-	if isinstance(path, str):
-		path = Path(path)
-	basedir = path.absolute()
-	with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as z:
-		for p in basedir.rglob("*"):
-			if p.is_dir():
-				continue
-			pathInBundle = p.relative_to(basedir)
-			if matchesNoPatterns(pathInBundle, excludePatterns):
-				z.write(p, pathInBundle)
-	return dest
 
 
 def format_nested_section(
@@ -179,7 +143,7 @@ vars.Add("versionNumber", "Version number of the form major.minor.patch", "0.0.0
 vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
 vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
 
-env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool", addonTool, manifestTool])
+env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool", "NVDATool", manifestTool])
 env.Append(**buildVars.addon_info)
 
 if env["dev"]:

--- a/sconstruct
+++ b/sconstruct
@@ -33,11 +33,6 @@ sys.dont_write_bytecode = True
 import buildVars  # NOQA: E402
 
 
-addonDir: Final = Path("addon/")
-localeDir: Final = addonDir / "locale"
-docsDir: Final = addonDir / "doc"
-
-
 def validateVersionNumber(key: str, val: str, _):
 	# Used to make sure version major.minor.patch are integers to comply with NV Access add-on store.
 	# Ignore all this if version number is not specified.
@@ -48,32 +43,6 @@ def validateVersionNumber(key: str, val: str, _):
 		raise ValueError(f"{key} must have three parts (major.minor.patch)")
 	if not all([part.isnumeric() for part in versionNumber]):
 		raise ValueError(f"{key} (major.minor.patch) must be integers")
-
-
-vars = Variables()
-vars.Add("version", "The version of this build", buildVars.addon_info["addon_version"])
-vars.Add("versionNumber", "Version number of the form major.minor.patch", "0.0.0", validateVersionNumber)
-vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
-vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
-
-env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool"])
-env.Append(**buildVars.addon_info)
-
-if env["dev"]:
-	from datetime import date
-
-	versionTimestamp = date.today().strftime('%Y%m%d')
-	version = f"{versionTimestamp}.0.0"
-	env["addon_version"] = version
-	env["versionNumber"] = version
-	env["channel"] = "dev"
-elif env["version"] is not None:
-	env["addon_version"] = env["version"]
-if "channel" in env and env["channel"] is not None:
-	env["addon_updateChannel"] = env["channel"]
-
-buildVars.addon_info["addon_version"] = env["addon_version"]
-buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
 
 
 def addonGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
@@ -101,11 +70,6 @@ def translatedManifestGenerator(target: list[FS.Entry], source: list[FS.Entry], 
 		lambda target, source, env: f"Generating translated manifest {target[0]}",
 	)
 	return action
-
-
-env["BUILDERS"]["NVDAAddon"] = Builder(generator=addonGenerator)
-env["BUILDERS"]["NVDAManifest"] = Builder(generator=manifestGenerator)
-env["BUILDERS"]["NVDATranslatedManifest"] = Builder(generator=translatedManifestGenerator)
 
 
 def matchesNoPatterns(path: Path, patterns: Iterable[str]) -> bool:
@@ -191,6 +155,42 @@ def generateTranslatedManifest(source: str, language: str, dest: str):
 
 def expandGlobs(patterns: Iterable[str], rootdir: Path = Path(".")) -> list[FS.Entry]:
 	return [env.Entry(e) for pattern in patterns for e in rootdir.glob(pattern.lstrip('/'))]
+
+
+addonDir: Final = Path("addon/")
+localeDir: Final = addonDir / "locale"
+docsDir: Final = addonDir / "doc"
+
+
+vars = Variables()
+vars.Add("version", "The version of this build", buildVars.addon_info["addon_version"])
+vars.Add("versionNumber", "Version number of the form major.minor.patch", "0.0.0", validateVersionNumber)
+vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
+vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
+
+env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool"])
+env.Append(**buildVars.addon_info)
+
+if env["dev"]:
+	from datetime import date
+
+	versionTimestamp = date.today().strftime('%Y%m%d')
+	version = f"{versionTimestamp}.0.0"
+	env["addon_version"] = version
+	env["versionNumber"] = version
+	env["channel"] = "dev"
+elif env["version"] is not None:
+	env["addon_version"] = env["version"]
+if "channel" in env and env["channel"] is not None:
+	env["addon_updateChannel"] = env["channel"]
+
+buildVars.addon_info["addon_version"] = env["addon_version"]
+buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
+
+
+env["BUILDERS"]["NVDAAddon"] = Builder(generator=addonGenerator)
+env["BUILDERS"]["NVDAManifest"] = Builder(generator=manifestGenerator)
+env["BUILDERS"]["NVDATranslatedManifest"] = Builder(generator=translatedManifestGenerator)
 
 
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")

--- a/sconstruct
+++ b/sconstruct
@@ -157,15 +157,20 @@ env["BUILDERS"]["NVDAManifest"] = Builder(generator=manifestGenerator)
 env["BUILDERS"]["NVDATranslatedManifest"] = Builder(generator=translatedManifestGenerator)
 
 
-def createAddonHelp(dir):
-	docsDir = os.path.join(dir, "doc")
-	if os.path.isfile("style.css"):
-		cssPath = os.path.join(docsDir, "style.css")
-		cssTarget = env.Command(cssPath, "style.css", Copy("$TARGET", "$SOURCE"))
+def createAddonHelp(dir: str|Path):
+	if isinstance(dir, str):
+		dir = Path(dir)
+
+	docsDir = dir / "doc"
+	cssFile = Path("style.css")
+	if cssFile.is_file():
+		cssPath = docsDir / cssFile
+		cssTarget = env.Command(str(cssPath), str(cssFile), Copy("$TARGET", "$SOURCE"))
 		env.Depends(addon, cssTarget)
-	if os.path.isfile("readme.md"):
-		readmePath = os.path.join(docsDir, buildVars.baseLanguage, "readme.md")
-		readmeTarget = env.Command(readmePath, "readme.md", Copy("$TARGET", "$SOURCE"))
+	readmeFile = Path("readme.md")
+	if readmeFile.is_file():
+		readmePath = docsDir / buildVars.baseLanguage / readmeFile
+		readmeTarget = env.Command(str(readmePath), str(readmeFile), Copy("$TARGET", "$SOURCE"))
 		env.Depends(addon, readmeTarget)
 
 

--- a/sconstruct
+++ b/sconstruct
@@ -38,28 +38,34 @@ localeDir: Final = addonDir / "locale"
 docsDir: Final = addonDir / "doc"
 
 
-def md2html(source: str|Path, dest: str):
+def md2html(
+		source: str|Path,
+		dest: str,
+		*,
+		localeDir: Path,
+		loacleFileName: str,
+		mdExtensions: list[str],
+		addonSummary: str,
+		addonVersion: str
+	):
 	if isinstance(source, str):
 		source = Path(source)
 
 	import markdown
 
 	# Use extensions if defined.
-	mdExtensions = buildVars.markdownExtensions
 	localeLang = source.parent.name
 	lang = localeLang.replace("_", "-")
 	try:
 		_ = gettext.translation(
-			"nvda",
+			loacleFileName,
 			localedir=localeDir,
 			languages=[localeLang]
 		).gettext
-		summary = _(buildVars.addon_info["addon_summary"])
+		summary = _(addonSummary)
 	except Exception:
-		summary = buildVars.addon_info["addon_summary"]
-	title = "{addonSummary} {addonVersion}".format(
-		addonSummary=summary, addonVersion=buildVars.addon_info["addon_version"]
-	)
+		summary = addonSummary
+	title = f"{summary} {addonVersion}"
 	headerDic = {
 		'[[!meta title="': "# ",
 		'"]]': " #",
@@ -89,8 +95,20 @@ def md2html(source: str|Path, dest: str):
 
 
 def mdTool(env: Environment):
+	env.SetDefault(localeDir = Path("locale/"))
+	env.SetDefault(localeFileName = "messages")
+	env.SetDefault(mdExtensions = {})
+
 	mdAction = env.Action(
-		lambda target, source, env: md2html(source[0].path, target[0].path),
+		lambda target, source, env: md2html(
+			source[0].path,
+			target[0].path,
+			localeDir=env["localeDir"],
+			loacleFileName=env["localeFileName"],
+			mdExtensions=env["mdExtensions"],
+			addonSummary=env["addon_summary"],
+			addonVersion=env["addon_version"]
+		),
 		lambda target, source, env: f"Generating {target[0]}",
 	)
 	mdBuilder = env.Builder(
@@ -304,7 +322,7 @@ for mdPath in docsDir.glob("*/*.md"):
 	lang = mdPath.absolute().parent.name
 	mdFile = env.File(mdPath)
 	moFile = moByLang.get(lang)
-	htmlFile = env.markdown(mdFile)
+	htmlFile = env.markdown(mdFile, localeDir=localeDir, localeFileName="nvda", mdExtensions=buildVars.markdownExtensions)
 	env.Depends(htmlFile, mdFile)
 	if moFile:
 		env.Depends(htmlFile, moFile)

--- a/sconstruct
+++ b/sconstruct
@@ -59,7 +59,6 @@ vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon
 env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool", "NVDATool"])
 env.Append(
 	addon_info=buildVars.addon_info,
-	localedir=localeDir,
 	brailleTables=buildVars.brailleTables,
 	symbolDictionaries=buildVars.symbolDictionaries,
 	**buildVars.addon_info

--- a/sconstruct
+++ b/sconstruct
@@ -56,7 +56,7 @@ vars.Add("versionNumber", "Version number of the form major.minor.patch", "0.0.0
 vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
 vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
 
-env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool", "NVDATool"])
+env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "NVDATool"])
 env.Append(
 	addon_info=buildVars.addon_info,
 	brailleTables=buildVars.brailleTables,

--- a/sconstruct
+++ b/sconstruct
@@ -30,7 +30,7 @@ EnsurePythonVersion(3, 10)
 sys.dont_write_bytecode = True
 
 import buildVars  # NOQA: E402
-from site_scons.site_tools.NVDATool.typings import Strable # NOQA: E402
+from site_scons.site_tools.NVDATool.typings import AddonInfo, BrailleTables, SymbolDictionaries, Strable # NOQA: E402
 
 
 def validateVersionNumber(key: str, val: str, _):
@@ -46,8 +46,17 @@ def validateVersionNumber(key: str, val: str, _):
 
 
 def manifestTool(env: Environment):
+	env.SetDefault(brailleTables={})
+	env.SetDefault(symbolDictionaries={})
+
 	action = env.Action(
-		lambda target, source, env: generateManifest(source[0].abspath, target[0].abspath) and None,
+		lambda target, source, env: generateManifest(
+			source[0].abspath,
+			target[0].abspath,
+			addon_info=env["addon_info"],
+			brailleTables=env["brailleTables"],
+			symbolDictionaries=env["symbolDictionaries"],
+		) and None,
 		lambda target, source, env: f"Generating manifest {target[0]}",
 	)
 	env["BUILDERS"]["NVDAManifest"] = Builder(
@@ -80,20 +89,25 @@ def format_nested_section(
 	return "\n".join(lines) + "\n"
 
 
-def generateManifest(source: str, dest: str):
+def generateManifest(
+		source: str,
+		dest: str,
+		addon_info: AddonInfo,
+		brailleTables: BrailleTables,
+		symbolDictionaries: SymbolDictionaries,
+	):
 	# Prepare the root manifest section
-	addon_info = buildVars.addon_info
 	with codecs.open(source, "r", "utf-8") as f:
 		manifest_template = f.read()
 	manifest = manifest_template.format(**addon_info)
 	# Add additional manifest sections such as custom braile tables
 	# Custom braille translation tables
-	if hasattr(buildVars, "brailleTables"):
-		manifest += format_nested_section("brailleTables", buildVars.brailleTables)
+	if brailleTables:
+		manifest += format_nested_section("brailleTables", brailleTables)
 
 	# Custom speech symbol dictionaries
-	if hasattr(buildVars, "symbolDictionaries"):
-		manifest += format_nested_section("symbolDictionaries", buildVars.symbolDictionaries)
+	if symbolDictionaries:
+		manifest += format_nested_section("symbolDictionaries", symbolDictionaries)
 
 	with codecs.open(dest, "w", "utf-8") as f:
 		f.write(manifest)
@@ -228,7 +242,10 @@ env.Alias("mergePot", mergePot)
 env.Depends(mergePot, i18nFiles)
 
 # Generate Manifest path
-manifest = env.NVDAManifest(env.File(addonDir/"manifest.ini"), "manifest.ini.tpl")
+manifest = env.NVDAManifest(env.File(addonDir/"manifest.ini"), "manifest.ini.tpl",
+							addon_info=buildVars.addon_info,
+							brailleTables=buildVars.brailleTables,
+							symbolDictionaries=buildVars.symbolDictionaries)
 # Ensure manifest is rebuilt if buildVars is updated.
 env.Depends(manifest, "buildVars.py")
 

--- a/sconstruct
+++ b/sconstruct
@@ -324,7 +324,7 @@ env.Alias("mergePot", mergePot)
 env.Depends(mergePot, i18nFiles)
 
 # Generate Manifest path
-manifest = env.NVDAManifest(addonDir/"manifest.ini", "manifest.ini.tpl")
+manifest = env.NVDAManifest(env.File(addonDir/"manifest.ini"), "manifest.ini.tpl")
 # Ensure manifest is rebuilt if buildVars is updated.
 env.Depends(manifest, "buildVars.py")
 

--- a/sconstruct
+++ b/sconstruct
@@ -106,13 +106,12 @@ env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", mdTool])
 env.Append(**buildVars.addon_info)
 
 if env["dev"]:
-	import datetime
+	from datetime import date
 
-	buildDate = datetime.datetime.now()
-	year, month, day = str(buildDate.year), str(buildDate.month), str(buildDate.day)
-	versionTimestamp = "".join([year, month.zfill(2), day.zfill(2)])
-	env["addon_version"] = f"{versionTimestamp}.0.0"
-	env["versionNumber"] = f"{versionTimestamp}.0.0"
+	versionTimestamp = date.today().strftime('%Y%m%d')
+	version = f"{versionTimestamp}.0.0"
+	env["addon_version"] = version
+	env["versionNumber"] = version
 	env["channel"] = "dev"
 elif env["version"] is not None:
 	env["addon_version"] = env["version"]

--- a/sconstruct
+++ b/sconstruct
@@ -118,7 +118,7 @@ for mdFile in env.Glob(docsDir/"*/*.md"):
 	# Thus, we find the moFile for this language and depend on it if it exists.
 	lang = mdFile.dir.name
 	moFile = moByLang.get(lang)
-	htmlFile = env.md2html(mdFile, localeDir=localeDir, localeFileName="nvda", mdExtensions=buildVars.markdownExtensions)
+	htmlFile = env.md2html(mdFile, moFile=moFile, mdExtensions=buildVars.markdownExtensions)
 	env.Depends(htmlFile, mdFile)
 	if moFile:
 		env.Depends(htmlFile, moFile)

--- a/sconstruct
+++ b/sconstruct
@@ -38,87 +38,6 @@ localeDir: Final = addonDir / "locale"
 docsDir: Final = addonDir / "doc"
 
 
-def md2html(
-		source: str|Path,
-		dest: str,
-		*,
-		localeDir: Path,
-		loacleFileName: str,
-		mdExtensions: list[str],
-		addonSummary: str,
-		addonVersion: str
-	):
-	if isinstance(source, str):
-		source = Path(source)
-
-	import markdown
-
-	# Use extensions if defined.
-	localeLang = source.parent.name
-	lang = localeLang.replace("_", "-")
-	try:
-		_ = gettext.translation(
-			loacleFileName,
-			localedir=localeDir,
-			languages=[localeLang]
-		).gettext
-		summary = _(addonSummary)
-	except Exception:
-		summary = addonSummary
-	title = f"{summary} {addonVersion}"
-	headerDic = {
-		'[[!meta title="': "# ",
-		'"]]': " #",
-	}
-	with codecs.open(str(source), "r", "utf-8") as f:
-		mdText = f.read()
-	for k, v in headerDic.items():
-		mdText = mdText.replace(k, v, 1)
-	htmlText = markdown.markdown(mdText, extensions=mdExtensions)
-	# Optimization: build resulting HTML text in one go instead of writing parts separately.
-	docText = "\n".join(
-		(
-			"<!DOCTYPE html>",
-			f'<html lang="{lang}">',
-			"<head>",
-			'<meta charset="UTF-8">',
-			'<meta name="viewport" content="width=device-width, initial-scale=1.0">',
-			'<link rel="stylesheet" type="text/css" href="../style.css" media="screen">',
-			f"<title>{title}</title>",
-			"</head>\n<body>",
-			htmlText,
-			"</body>\n</html>",
-		)
-	)
-	with codecs.open(dest, "w", "utf-8") as f:
-		f.write(docText)
-
-
-def mdTool(env: Environment):
-	env.SetDefault(localeDir = Path("locale/"))
-	env.SetDefault(localeFileName = "messages")
-	env.SetDefault(mdExtensions = {})
-
-	mdAction = env.Action(
-		lambda target, source, env: md2html(
-			source[0].path,
-			target[0].path,
-			localeDir=env["localeDir"],
-			loacleFileName=env["localeFileName"],
-			mdExtensions=env["mdExtensions"],
-			addonSummary=env["addon_summary"],
-			addonVersion=env["addon_version"]
-		),
-		lambda target, source, env: f"Generating {target[0]}",
-	)
-	mdBuilder = env.Builder(
-		action=mdAction,
-		suffix=".html",
-		src_suffix=".md",
-	)
-	env["BUILDERS"]["markdown"] = mdBuilder
-
-
 def validateVersionNumber(key: str, val: str, _):
 	# Used to make sure version major.minor.patch are integers to comply with NV Access add-on store.
 	# Ignore all this if version number is not specified.
@@ -137,7 +56,7 @@ vars.Add("versionNumber", "Version number of the form major.minor.patch", "0.0.0
 vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
 vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
 
-env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", mdTool])
+env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool"])
 env.Append(**buildVars.addon_info)
 
 if env["dev"]:

--- a/sconstruct
+++ b/sconstruct
@@ -269,9 +269,8 @@ def generateTranslatedManifest(source: str, language: str, out: str):
 		f.write(result)
 
 
-def expandGlobs(patterns: Iterable[str]) -> list[FS.File]:
-	base = Path(".")
-	return [env.File(f) for pattern in patterns for f in base.glob(pattern.lstrip('/'))]
+def expandGlobs(patterns: Iterable[str], rootdir: Path = Path(".")) -> list[FS.Entry]:
+	return [env.Entry(e) for pattern in patterns for e in rootdir.glob(pattern.lstrip('/'))]
 
 
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")

--- a/sconstruct
+++ b/sconstruct
@@ -70,8 +70,14 @@ def translatedManifestGenerator(target: list[FS.Entry], source: list[FS.Entry], 
 	dir = Path(str(source[0])).absolute().parents[1]
 	lang = dir.name
 	action = env.Action(
-		lambda target, source, env: generateTranslatedManifest(source[1].abspath, lang, target[0].abspath)
-		and None,
+		lambda target, source, env: generateTranslatedManifest(
+			source[1].abspath,
+			target[0].abspath,
+			lang, env["localedir"],
+			addon_info=env["addon_info"],
+			brailleTables=env["brailleTables"],
+			symbolDictionaries=env["symbolDictionaries"],
+		) and None,
 		lambda target, source, env: f"Generating translated manifest {target[0]}",
 	)
 	return action
@@ -113,11 +119,19 @@ def generateManifest(
 		f.write(manifest)
 
 
-def generateTranslatedManifest(source: str, language: str, dest: str):
+def generateTranslatedManifest(
+		source: str,
+		dest: str,
+		language: str,
+		localeDir: str,
+		addon_info: AddonInfo,
+		brailleTables: BrailleTables,
+		symbolDictionaries: SymbolDictionaries,
+	):
 	_ = gettext.translation("nvda", localedir=localeDir, languages=[language]).gettext
 	vars: dict[str, str] = {}
 	for var in ("addon_summary", "addon_description"):
-		vars[var] = _(buildVars.addon_info[var])
+		vars[var] = _(addon_info[var])
 	with codecs.open(source, "r", "utf-8") as f:
 		manifest_template = f.read()
 	manifest = manifest_template.format(**vars)
@@ -132,12 +146,12 @@ def generateTranslatedManifest(source: str, language: str, dest: str):
 
 	# Add additional manifest sections such as custom braile tables
 	# Custom braille translation tables
-	if tables := getattr(buildVars, "brailleTables", None):
-		manifest += _format_section_only_with_displayName("brailleTables", tables)
+	if brailleTables:
+		manifest += _format_section_only_with_displayName("brailleTables", brailleTables)
 
 	# Custom speech symbol dictionaries
-	if dicts := getattr(buildVars, "symbolDictionaries", None):
-		manifest += _format_section_only_with_displayName("symbolDictionaries", dicts)
+	if symbolDictionaries:
+		manifest += _format_section_only_with_displayName("symbolDictionaries", symbolDictionaries)
 
 	with codecs.open(dest, "w", "utf-8") as f:
 		f.write(manifest)
@@ -159,7 +173,13 @@ vars.Add(BoolVariable("dev", "Whether this is a daily development version", Fals
 vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
 
 env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool", "NVDATool", manifestTool])
-env.Append(**buildVars.addon_info)
+env.Append(
+	addon_info=buildVars.addon_info,
+	localedir=localeDir,
+	brailleTables=buildVars.brailleTables,
+	symbolDictionaries=buildVars.symbolDictionaries,
+	**buildVars.addon_info
+)
 
 if env["dev"]:
 	from datetime import date
@@ -242,10 +262,7 @@ env.Alias("mergePot", mergePot)
 env.Depends(mergePot, i18nFiles)
 
 # Generate Manifest path
-manifest = env.NVDAManifest(env.File(addonDir/"manifest.ini"), "manifest.ini.tpl",
-							addon_info=buildVars.addon_info,
-							brailleTables=buildVars.brailleTables,
-							symbolDictionaries=buildVars.symbolDictionaries)
+manifest = env.NVDAManifest(env.File(addonDir/"manifest.ini"), "manifest.ini.tpl")
 # Ensure manifest is rebuilt if buildVars is updated.
 env.Depends(manifest, "buildVars.py")
 

--- a/sconstruct
+++ b/sconstruct
@@ -161,11 +161,10 @@ env["BUILDERS"]["NVDAManifest"] = Builder(generator=manifestGenerator)
 env["BUILDERS"]["NVDATranslatedManifest"] = Builder(generator=translatedManifestGenerator)
 
 
-def createAddonHelp(dir: str|Path):
-	if isinstance(dir, str):
-		dir = Path(dir)
+def createAddonHelp(docsDir: str|Path):
+	if isinstance(docsDir, str):
+		docsDir = Path(docsDir)
 
-	docsDir = dir / "doc"
 	cssFile = Path("style.css")
 	if cssFile.is_file():
 		cssPath = docsDir / cssFile
@@ -289,7 +288,7 @@ for file in pythonFiles:
 
 # Convert markdown files to html
 # We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
-createAddonHelp(addonDir)
+createAddonHelp(docsDir)
 for mdPath in docsDir.glob("*/*.md"):
 	# the title of the html file is translated based on the contents of something in the moFile for a language.
 	# Thus, we find the moFile for this language and depend on it if it exists.

--- a/sconstruct
+++ b/sconstruct
@@ -17,7 +17,7 @@ from typing import Final
 # Linters aren't aware about them.
 # To avoid PyRight `reportUndefinedVariable` errors about them they are imported explicitly.
 # When using other  Scons functions please add them to the line below.
-from SCons.Script import EnsurePythonVersion, Variables, BoolVariable, Environment
+from SCons.Script import EnsurePythonVersion, Variables, BoolVariable, Environment, Builder, Copy
 from SCons.Node import FS
 
 # Add-on localization exchange facility and the template requires Python 3.10.

--- a/sconstruct
+++ b/sconstruct
@@ -152,7 +152,7 @@ def generateManifest(source: str, dest: str):
 	manifest = manifest_template.format(**addon_info)
 	# Add additional manifest sections such as custom braile tables
 	# Custom braille translation tables
-	if getattr(buildVars, "brailleTables", {}):
+	if hasattr(buildVars, "brailleTables"):
 		manifest_brailleTables = ["\n[brailleTables]"]
 		for table in buildVars.brailleTables.keys():
 			manifest_brailleTables.append(f"[[{table}]]")
@@ -161,7 +161,7 @@ def generateManifest(source: str, dest: str):
 		manifest += "\n".join(manifest_brailleTables) + "\n"
 
 	# Custom speech symbol dictionaries
-	if getattr(buildVars, "symbolDictionaries", {}):
+	if hasattr(buildVars, "symbolDictionaries"):
 		manifest_symbolDictionaries = ["\n[symbolDictionaries]"]
 		for dictionary in buildVars.symbolDictionaries.keys():
 			manifest_symbolDictionaries.append(f"[[{dictionary}]]")
@@ -183,7 +183,7 @@ def generateTranslatedManifest(source: str, language: str, out: str):
 	result = manifest_template.format(**vars)
 	# Add additional manifest sections such as custom braile tables
 	# Custom braille translation tables
-	if getattr(buildVars, "brailleTables", {}):
+	if hasattr(buildVars, "brailleTables"):
 		result_brailleTables = ["\n[brailleTables]"]
 		for table in buildVars.brailleTables.keys():
 			result_brailleTables.append(f"[[{table}]]")
@@ -192,7 +192,7 @@ def generateTranslatedManifest(source: str, language: str, out: str):
 		result += "\n".join(result_brailleTables) + "\n"
 
 	# Custom speech symbol dictionaries
-	if getattr(buildVars, "symbolDictionaries", {}):
+	if hasattr(buildVars, "symbolDictionaries"):
 		result_symbolDictionaries = ["\n[symbolDictionaries]"]
 		for dictionary in buildVars.symbolDictionaries.keys():
 			result_symbolDictionaries.append(f"[[{dictionary}]]")

--- a/sconstruct
+++ b/sconstruct
@@ -81,20 +81,21 @@ if "channel" in env and env["channel"] is not None:
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
 addon = env.NVDAAddon(addonFile, env.Dir(addonDir), excludePatterns=buildVars.excludedFiles)
 
-langDirs: list[FS.Dir] = [d for d in env.Glob(localeDir/"*/")]
+langDirs: list[FS.Dir] = [env.Dir(d) for d in env.Glob(localeDir/"*/") if d.isdir()]
 
 # Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
-moByLang: dict[FS.Dir, FS.File] = {}
+moByLang: dict[str, FS.File] = {}
 for dir in langDirs:
 	poFile = dir.File(os.path.join("LC_MESSAGES", "nvda.po"))
-	moFile = env.gettextMoFile(poFile)
-	moByLang[dir] = moFile
-	env.Depends(moFile, poFile)
+	moTarget = env.gettextMoFile(poFile)
+	moFile = env.File(moTarget[0])
+	moByLang[dir.name] = moFile
+	env.Depends(moTarget, poFile)
 	translatedManifest = env.NVDATranslatedManifest(
 		dir.File("manifest.ini"), [moFile, "manifest-translated.ini.tpl"]
 	)
 	env.Depends(translatedManifest, ["buildVars.py"])
-	env.Depends(addon, [translatedManifest, moFile])
+	env.Depends(addon, [translatedManifest, moTarget])
 
 pythonFiles = expandGlobs(buildVars.pythonSources)
 for file in pythonFiles:
@@ -115,7 +116,7 @@ if (readmeFile := Path("readme.md")).is_file():
 for mdFile in env.Glob(docsDir/"*/*.md"):
 	# the title of the html file is translated based on the contents of something in the moFile for a language.
 	# Thus, we find the moFile for this language and depend on it if it exists.
-	lang = Path(str(mdFile)).absolute().parent.name
+	lang = mdFile.dir.name
 	moFile = moByLang.get(lang)
 	htmlFile = env.md2html(mdFile, localeDir=localeDir, localeFileName="nvda", mdExtensions=buildVars.markdownExtensions)
 	env.Depends(htmlFile, mdFile)

--- a/sconstruct
+++ b/sconstruct
@@ -11,6 +11,7 @@ import zipfile
 import sys
 from pathlib import Path
 from collections.abc import Iterable
+from typing import Final
 
 # Add-on localization exchange facility and the template requires Python 3.10.
 # For best practice, use Python 3.11 or later to align with NVDA development.
@@ -20,6 +21,10 @@ EnsurePythonVersion(3, 10)
 sys.dont_write_bytecode = True
 
 import buildVars  # NOQA: E402
+
+
+addonDir: Final = Path("addon/")
+localeDir: Final = addonDir / "locale"
 
 
 def md2html(source: str|Path, dest: str):
@@ -35,7 +40,7 @@ def md2html(source: str|Path, dest: str):
 	try:
 		_ = gettext.translation(
 			"nvda",
-			localedir=os.path.join("addon", "locale"),
+			localedir=localeDir,
 			languages=[localeLang]
 		).gettext
 		summary = _(buildVars.addon_info["addon_summary"])
@@ -142,8 +147,8 @@ def manifestGenerator(target, source, env, for_signature):
 
 
 def translatedManifestGenerator(target, source, env, for_signature):
-	dir = os.path.abspath(os.path.join(os.path.dirname(str(source[0])), ".."))
-	lang = os.path.basename(dir)
+	dir = Path(str(source[0])).absolute().parents[1]
+	lang = dir.name
 	action = env.Action(
 		lambda target, source, env: generateTranslatedManifest(source[1].abspath, lang, target[0].abspath)
 		and None,
@@ -224,7 +229,7 @@ def generateManifest(source, dest):
 
 
 def generateTranslatedManifest(source, language, out):
-	_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).gettext
+	_ = gettext.translation("nvda", localedir=localeDir, languages=[language]).gettext
 	vars = {}
 	for var in ("addon_summary", "addon_description"):
 		vars[var] = _(buildVars.addon_info[var])
@@ -263,7 +268,7 @@ def expandGlobs(patterns: Iterable[str]) -> list:
 
 addon = env.NVDAAddon(addonFile, env.Dir("addon"))
 
-langDirs = [f for f in env.Glob(os.path.join("addon", "locale", "*"))]
+langDirs = [f for f in env.Glob(localeDir/"*")]
 
 # Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
 moByLang = {}
@@ -285,10 +290,10 @@ for file in pythonFiles:
 # Convert markdown files to html
 # We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
 createAddonHelp("addon")
-for mdFile in env.Glob(os.path.join("addon", "doc", "*", "*.md")):
+for mdFile in env.Glob(addonDir/"doc/*/*.md"):
 	# the title of the html file is translated based on the contents of something in the moFile for a language.
 	# Thus, we find the moFile for this language and depend on it if it exists.
-	lang = os.path.basename(os.path.dirname(mdFile.get_abspath()))
+	lang = Path(mdFile.get_abspath()).parent.name
 	moFile = moByLang.get(lang)
 	htmlFile = env.markdown(mdFile)
 	env.Depends(htmlFile, mdFile)
@@ -312,7 +317,7 @@ env.Alias("mergePot", mergePot)
 env.Depends(mergePot, i18nFiles)
 
 # Generate Manifest path
-manifest = env.NVDAManifest(os.path.join("addon", "manifest.ini"), "manifest.ini.tpl")
+manifest = env.NVDAManifest(addonDir/"manifest.ini", "manifest.ini.tpl")
 # Ensure manifest is rebuilt if buildVars is updated.
 env.Depends(manifest, "buildVars.py")
 

--- a/sconstruct
+++ b/sconstruct
@@ -108,22 +108,6 @@ env["BUILDERS"]["NVDAManifest"] = Builder(generator=manifestGenerator)
 env["BUILDERS"]["NVDATranslatedManifest"] = Builder(generator=translatedManifestGenerator)
 
 
-def createAddonHelp(docsDir: str|Path):
-	if isinstance(docsDir, str):
-		docsDir = Path(docsDir)
-
-	cssFile = Path("style.css")
-	if cssFile.is_file():
-		cssPath = docsDir / cssFile
-		cssTarget = env.Command(str(cssPath), str(cssFile), Copy("$TARGET", "$SOURCE"))
-		env.Depends(addon, cssTarget)
-	readmeFile = Path("readme.md")
-	if readmeFile.is_file():
-		readmePath = docsDir / buildVars.baseLanguage / readmeFile
-		readmeTarget = env.Command(str(readmePath), str(readmeFile), Copy("$TARGET", "$SOURCE"))
-		env.Depends(addon, readmeTarget)
-
-
 def matchesNoPatterns(path: Path, patterns: Iterable[str]) -> bool:
 	"""Checks if the path, the first argument, does not match any of the patterns passed as the second argument."""
 	return not any((path.match(pattern) for pattern in patterns))
@@ -233,7 +217,16 @@ for file in pythonFiles:
 
 # Convert markdown files to html
 # We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
-createAddonHelp(docsDir)
+if (cssFile := Path("style.css")).is_file():
+	cssPath = docsDir / cssFile
+	cssTarget = env.Command(str(cssPath), str(cssFile), Copy("$TARGET", "$SOURCE"))
+	env.Depends(addon, cssTarget)
+
+if (readmeFile := Path("readme.md")).is_file():
+	readmePath = docsDir / buildVars.baseLanguage / readmeFile
+	readmeTarget = env.Command(str(readmePath), str(readmeFile), Copy("$TARGET", "$SOURCE"))
+	env.Depends(addon, readmeTarget)
+
 for mdFile in env.Glob(docsDir/"*/*.md"):
 	# the title of the html file is translated based on the contents of something in the moFile for a language.
 	# Thus, we find the moFile for this language and depend on it if it exists.

--- a/sconstruct
+++ b/sconstruct
@@ -25,6 +25,7 @@ import buildVars  # NOQA: E402
 
 addonDir: Final = Path("addon/")
 localeDir: Final = addonDir / "locale"
+docsDir: Final = addonDir / "doc"
 
 
 def md2html(source: str|Path, dest: str):
@@ -289,10 +290,11 @@ for file in pythonFiles:
 # Convert markdown files to html
 # We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
 createAddonHelp(addonDir)
-for mdFile in env.Glob(addonDir/"doc/*/*.md"):
+for mdPath in docsDir.glob("*/*.md"):
 	# the title of the html file is translated based on the contents of something in the moFile for a language.
 	# Thus, we find the moFile for this language and depend on it if it exists.
-	lang = Path(mdFile.get_abspath()).parent.name
+	lang = mdPath.absolute().parent.name
+	mdFile = env.File(mdPath)
 	moFile = moByLang.get(lang)
 	htmlFile = env.markdown(mdFile)
 	env.Depends(htmlFile, mdFile)

--- a/sconstruct
+++ b/sconstruct
@@ -3,13 +3,11 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING.txt for more details.
 
-import codecs
-import gettext
 import os
 import os.path
 import sys
 from pathlib import Path
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from typing import Final
 
 # While names imported below are available by default in every SConscript
@@ -20,7 +18,6 @@ from SCons.Script import EnsurePythonVersion, Variables, BoolVariable, Environme
 
 # Imports for type hints
 from SCons.Node import FS
-from SCons.Action import CommandAction
 
 # Add-on localization exchange facility and the template requires Python 3.10.
 # For best practice, use Python 3.11 or later to align with NVDA development.
@@ -30,7 +27,6 @@ EnsurePythonVersion(3, 10)
 sys.dont_write_bytecode = True
 
 import buildVars  # NOQA: E402
-from site_scons.site_tools.NVDATool.typings import AddonInfo, BrailleTables, SymbolDictionaries, Strable # NOQA: E402
 
 
 def validateVersionNumber(key: str, val: str, _):
@@ -43,118 +39,6 @@ def validateVersionNumber(key: str, val: str, _):
 		raise ValueError(f"{key} must have three parts (major.minor.patch)")
 	if not all([part.isnumeric() for part in versionNumber]):
 		raise ValueError(f"{key} (major.minor.patch) must be integers")
-
-
-def manifestTool(env: Environment):
-	env.SetDefault(brailleTables={})
-	env.SetDefault(symbolDictionaries={})
-
-	action = env.Action(
-		lambda target, source, env: generateManifest(
-			source[0].abspath,
-			target[0].abspath,
-			addon_info=env["addon_info"],
-			brailleTables=env["brailleTables"],
-			symbolDictionaries=env["symbolDictionaries"],
-		) and None,
-		lambda target, source, env: f"Generating manifest {target[0]}",
-	)
-	env["BUILDERS"]["NVDAManifest"] = Builder(
-		action=action,
-		suffix=".ini",
-		src_siffix=".ini.tpl"
-	)
-
-
-def translatedManifestGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
-	dir = Path(str(source[0])).absolute().parents[1]
-	lang = dir.name
-	action = env.Action(
-		lambda target, source, env: generateTranslatedManifest(
-			source[1].abspath,
-			target[0].abspath,
-			lang, env["localedir"],
-			addon_info=env["addon_info"],
-			brailleTables=env["brailleTables"],
-			symbolDictionaries=env["symbolDictionaries"],
-		) and None,
-		lambda target, source, env: f"Generating translated manifest {target[0]}",
-	)
-	return action
-
-
-def format_nested_section(
-	section_name: str,
-	data: Mapping[str, Mapping[str, Strable]]
-) -> str:
-	lines = [f"\n[{section_name}]"]
-	for item_name, inner_dict in data.items():
-		lines.append(f"[[{item_name}]]")
-		for key, val in inner_dict.items():
-			lines.append(f"{key} = {val}")
-	return "\n".join(lines) + "\n"
-
-
-def generateManifest(
-		source: str,
-		dest: str,
-		addon_info: AddonInfo,
-		brailleTables: BrailleTables,
-		symbolDictionaries: SymbolDictionaries,
-	):
-	# Prepare the root manifest section
-	with codecs.open(source, "r", "utf-8") as f:
-		manifest_template = f.read()
-	manifest = manifest_template.format(**addon_info)
-	# Add additional manifest sections such as custom braile tables
-	# Custom braille translation tables
-	if brailleTables:
-		manifest += format_nested_section("brailleTables", brailleTables)
-
-	# Custom speech symbol dictionaries
-	if symbolDictionaries:
-		manifest += format_nested_section("symbolDictionaries", symbolDictionaries)
-
-	with codecs.open(dest, "w", "utf-8") as f:
-		f.write(manifest)
-
-
-def generateTranslatedManifest(
-		source: str,
-		dest: str,
-		language: str,
-		localeDir: str,
-		addon_info: AddonInfo,
-		brailleTables: BrailleTables,
-		symbolDictionaries: SymbolDictionaries,
-	):
-	_ = gettext.translation("nvda", localedir=localeDir, languages=[language]).gettext
-	vars: dict[str, str] = {}
-	for var in ("addon_summary", "addon_description"):
-		vars[var] = _(addon_info[var])
-	with codecs.open(source, "r", "utf-8") as f:
-		manifest_template = f.read()
-	manifest = manifest_template.format(**vars)
-
-	def _format_section_only_with_displayName(section_name: str, data: Mapping[str, Mapping[str, Strable]]) -> str:
-		lines = [f"\n[{section_name}]"]
-		for item, inner_dict in data.items():
-			lines.append(f"[[{item}]]")
-			# Fetch display name only.
-			lines.append(f"displayName = {_(inner_dict['displayName'])}")
-		return "\n".join(lines) + "\n"
-
-	# Add additional manifest sections such as custom braile tables
-	# Custom braille translation tables
-	if brailleTables:
-		manifest += _format_section_only_with_displayName("brailleTables", brailleTables)
-
-	# Custom speech symbol dictionaries
-	if symbolDictionaries:
-		manifest += _format_section_only_with_displayName("symbolDictionaries", symbolDictionaries)
-
-	with codecs.open(dest, "w", "utf-8") as f:
-		f.write(manifest)
 
 
 def expandGlobs(patterns: Iterable[str], rootdir: Path = Path(".")) -> list[FS.Entry]:
@@ -172,7 +56,7 @@ vars.Add("versionNumber", "Version number of the form major.minor.patch", "0.0.0
 vars.Add(BoolVariable("dev", "Whether this is a daily development version", False))
 vars.Add("channel", "Update channel for this build", buildVars.addon_info["addon_updateChannel"])
 
-env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool", "NVDATool", manifestTool])
+env = Environment(variables=vars, ENV=os.environ, tools=["gettexttool", "mdTool", "NVDATool"])
 env.Append(
 	addon_info=buildVars.addon_info,
 	localedir=localeDir,
@@ -196,9 +80,6 @@ if "channel" in env and env["channel"] is not None:
 
 buildVars.addon_info["addon_version"] = env["addon_version"]
 buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
-
-
-env["BUILDERS"]["NVDATranslatedManifest"] = Builder(generator=translatedManifestGenerator)
 
 
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")

--- a/sconstruct
+++ b/sconstruct
@@ -266,7 +266,7 @@ def expandGlobs(patterns: Iterable[str]) -> list:
 	return [env.File(f) for pattern in patterns for f in base.glob(pattern.lstrip('/'))]
 
 
-addon = env.NVDAAddon(addonFile, env.Dir("addon"))
+addon = env.NVDAAddon(addonFile, env.Dir(addonDir))
 
 langDirs = [f for f in env.Glob(localeDir/"*")]
 
@@ -289,7 +289,7 @@ for file in pythonFiles:
 
 # Convert markdown files to html
 # We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
-createAddonHelp("addon")
+createAddonHelp(addonDir)
 for mdFile in env.Glob(addonDir/"doc/*/*.md"):
 	# the title of the html file is translated based on the contents of something in the moFile for a language.
 	# Thus, we find the moFile for this language and depend on it if it exists.

--- a/sconstruct
+++ b/sconstruct
@@ -61,7 +61,6 @@ env.Append(
 	addon_info=buildVars.addon_info,
 	brailleTables=buildVars.brailleTables,
 	symbolDictionaries=buildVars.symbolDictionaries,
-	**buildVars.addon_info
 )
 
 if env["dev"]:
@@ -69,13 +68,16 @@ if env["dev"]:
 
 	versionTimestamp = date.today().strftime('%Y%m%d')
 	version = f"{versionTimestamp}.0.0"
-	env["addon_version"] = version
+	env["addon_info"]["addon_version"] = version
 	env["versionNumber"] = version
 	env["channel"] = "dev"
 elif env["version"] is not None:
-	env["addon_version"] = env["version"]
+	env["addon_info"]["addon_version"] = env["version"]
 if "channel" in env and env["channel"] is not None:
-	env["addon_updateChannel"] = env["channel"]
+	env["addon_info"]["addon_updateChannel"] = env["channel"]
+
+# This is necessary for further use in formatting file names.
+env.Append(**env["addon_info"])
 
 
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")

--- a/sconstruct
+++ b/sconstruct
@@ -175,7 +175,7 @@ def generateManifest(source: str, dest: str):
 
 def generateTranslatedManifest(source: str, language: str, out: str):
 	_ = gettext.translation("nvda", localedir=localeDir, languages=[language]).gettext
-	vars = {}
+	vars: dict[str, str] = {}
 	for var in ("addon_summary", "addon_description"):
 		vars[var] = _(buildVars.addon_info[var])
 	with codecs.open(source, "r", "utf-8") as f:
@@ -248,7 +248,7 @@ for mdFile in env.Glob(docsDir/"*/*.md"):
 
 # Pot target
 i18nFiles = expandGlobs(buildVars.i18nSources)
-gettextvars = {
+gettextvars: dict[str, str] = {
 	"gettext_package_bugs_address": "nvda-translations@groups.io",
 	"gettext_package_name": buildVars.addon_info["addon_name"],
 	"gettext_package_version": buildVars.addon_info["addon_version"],

--- a/sconstruct
+++ b/sconstruct
@@ -174,7 +174,7 @@ def createAddonHelp(dir: str|Path):
 		env.Depends(addon, readmeTarget)
 
 
-def machesNoPatterns(path: Path, patterns: list[str]) -> bool:
+def matchesNoPatterns(path: Path, patterns: list[str]) -> bool:
 	return all([not path.match(pattern) for pattern in patterns])
 
 
@@ -188,7 +188,7 @@ def createAddonBundleFromPath(path: str|Path, dest: str):
 			if p.is_dir():
 				continue
 			pathInBundle = p.relative_to(basedir)
-			if machesNoPatterns(pathInBundle, buildVars.excludedFiles):
+			if matchesNoPatterns(pathInBundle, buildVars.excludedFiles):
 				z.write(p, pathInBundle)
 	return dest
 

--- a/sconstruct
+++ b/sconstruct
@@ -9,8 +9,8 @@ import os
 import os.path
 import sys
 from pathlib import Path
-from collections.abc import Iterable
-from typing import Final, Mapping
+from collections.abc import Iterable, Mapping
+from typing import Final
 
 # While names imported below are available by default in every SConscript
 # Linters aren't aware about them.

--- a/sconstruct
+++ b/sconstruct
@@ -175,37 +175,34 @@ def generateManifest(source: str, dest: str):
 		f.write(manifest)
 
 
-def generateTranslatedManifest(source: str, language: str, out: str):
+def generateTranslatedManifest(source: str, language: str, dest: str):
 	_ = gettext.translation("nvda", localedir=localeDir, languages=[language]).gettext
 	vars: dict[str, str] = {}
 	for var in ("addon_summary", "addon_description"):
 		vars[var] = _(buildVars.addon_info[var])
 	with codecs.open(source, "r", "utf-8") as f:
 		manifest_template = f.read()
-	result = manifest_template.format(**vars)
+	manifest = manifest_template.format(**vars)
+
+	def _format_section_only_with_displayName(section_name: str, data: Mapping[str, Mapping[str, str]]) -> str:
+		lines = [f"\n[{section_name}]"]
+		for item, inner_dict in data.items():
+			lines.append(f"[[{item}]]")
+			# Fetch display name only.
+			lines.append(f"displayName = {_(inner_dict['displayName'])}")
+		return "\n".join(lines) + "\n"
+
 	# Add additional manifest sections such as custom braile tables
 	# Custom braille translation tables
-	if hasattr(buildVars, "brailleTables"):
-		result_brailleTables = ["\n[brailleTables]"]
-		for table in buildVars.brailleTables.keys():
-			result_brailleTables.append(f"[[{table}]]")
-			# Fetch display name only.
-			result_brailleTables.append(f"displayName = {_(buildVars.brailleTables[table]['displayName'])}")
-		result += "\n".join(result_brailleTables) + "\n"
+	if tables := getattr(buildVars, "brailleTables", None):
+		manifest += _format_section_only_with_displayName("brailleTables", tables)
 
 	# Custom speech symbol dictionaries
-	if hasattr(buildVars, "symbolDictionaries"):
-		result_symbolDictionaries = ["\n[symbolDictionaries]"]
-		for dictionary in buildVars.symbolDictionaries.keys():
-			result_symbolDictionaries.append(f"[[{dictionary}]]")
-			# Fetch display name only.
-			result_symbolDictionaries.append(
-				f"displayName = {_(buildVars.symbolDictionaries[dictionary]['displayName'])}"
-			)
-		result += "\n".join(result_symbolDictionaries) + "\n"
+	if dicts := getattr(buildVars, "symbolDictionaries", None):
+		manifest += _format_section_only_with_displayName("symbolDictionaries", dicts)
 
-	with codecs.open(out, "w", "utf-8") as f:
-		f.write(result)
+	with codecs.open(dest, "w", "utf-8") as f:
+		f.write(manifest)
 
 
 def expandGlobs(patterns: Iterable[str], rootdir: Path = Path(".")) -> list[FS.Entry]:

--- a/sconstruct
+++ b/sconstruct
@@ -213,7 +213,7 @@ def expandGlobs(patterns: Iterable[str], rootdir: Path = Path(".")) -> list[FS.E
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
 addon = env.NVDAAddon(addonFile, env.Dir(addonDir))
 
-langDirs: list[FS.Dir] = [env.Dir(d) for d in localeDir.glob("*/")]
+langDirs: list[FS.Dir] = [d for d in env.Glob(localeDir/"*/")]
 
 # Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
 moByLang: dict[FS.Dir, FS.File] = {}
@@ -235,11 +235,10 @@ for file in pythonFiles:
 # Convert markdown files to html
 # We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
 createAddonHelp(docsDir)
-for mdPath in docsDir.glob("*/*.md"):
+for mdFile in env.Glob(docsDir/"*/*.md"):
 	# the title of the html file is translated based on the contents of something in the moFile for a language.
 	# Thus, we find the moFile for this language and depend on it if it exists.
-	lang = mdPath.absolute().parent.name
-	mdFile = env.File(mdPath)
+	lang = Path(str(mdFile)).absolute().parent.name
 	moFile = moByLang.get(lang)
 	htmlFile = env.markdown(mdFile, localeDir=localeDir, localeFileName="nvda", mdExtensions=buildVars.markdownExtensions)
 	env.Depends(htmlFile, mdFile)

--- a/sconstruct
+++ b/sconstruct
@@ -84,16 +84,16 @@ def mdTool(env):
 	env["BUILDERS"]["markdown"] = mdBuilder
 
 
-def validateVersionNumber(key, val, env):
+def validateVersionNumber(key: str, val: str, _):
 	# Used to make sure version major.minor.patch are integers to comply with NV Access add-on store.
 	# Ignore all this if version number is not specified.
 	if val == "0.0.0":
 		return
 	versionNumber = val.split(".")
 	if len(versionNumber) < 3:
-		raise ValueError("versionNumber must have three parts (major.minor.patch)")
+		raise ValueError(f"{key} must have three parts (major.minor.patch)")
 	if not all([part.isnumeric() for part in versionNumber]):
-		raise ValueError("versionNumber (major.minor.patch) must be integers")
+		raise ValueError(f"{key} (major.minor.patch) must be integers")
 
 
 vars = Variables()

--- a/sconstruct
+++ b/sconstruct
@@ -256,8 +256,9 @@ def generateTranslatedManifest(source, language, out):
 		f.write(result)
 
 
-def expandGlobs(files):
-	return [f for pattern in files for f in env.Glob(pattern)]
+def expandGlobs(patterns: Iterable[str]) -> list:
+	base = Path(".")
+	return [env.File(f) for pattern in patterns for f in base.glob(pattern.lstrip('/'))]
 
 
 addon = env.NVDAAddon(addonFile, env.Dir("addon"))

--- a/sconstruct
+++ b/sconstruct
@@ -21,16 +21,21 @@ sys.dont_write_bytecode = True
 import buildVars  # NOQA: E402
 
 
-def md2html(source, dest):
+def md2html(source: str|Path, dest: str):
+	if isinstance(source, str):
+		source = Path(source)
+
 	import markdown
 
 	# Use extensions if defined.
 	mdExtensions = buildVars.markdownExtensions
-	lang = os.path.basename(os.path.dirname(source)).replace("_", "-")
-	localeLang = os.path.basename(os.path.dirname(source))
+	localeLang = source.parent.name
+	lang = localeLang.replace("_", "-")
 	try:
 		_ = gettext.translation(
-			"nvda", localedir=os.path.join("addon", "locale"), languages=[localeLang]
+			"nvda",
+			localedir=os.path.join("addon", "locale"),
+			languages=[localeLang]
 		).gettext
 		summary = _(buildVars.addon_info["addon_summary"])
 	except Exception:
@@ -42,14 +47,14 @@ def md2html(source, dest):
 		'[[!meta title="': "# ",
 		'"]]': " #",
 	}
-	with codecs.open(source, "r", "utf-8") as f:
+	with codecs.open(str(source), "r", "utf-8") as f:
 		mdText = f.read()
-		for k, v in headerDic.items():
-			mdText = mdText.replace(k, v, 1)
-		htmlText = markdown.markdown(mdText, extensions=mdExtensions)
+	for k, v in headerDic.items():
+		mdText = mdText.replace(k, v, 1)
+	htmlText = markdown.markdown(mdText, extensions=mdExtensions)
 	# Optimization: build resulting HTML text in one go instead of writing parts separately.
 	docText = "\n".join(
-		[
+		(
 			"<!DOCTYPE html>",
 			f'<html lang="{lang}">',
 			"<head>",
@@ -60,7 +65,7 @@ def md2html(source, dest):
 			"</head>\n<body>",
 			htmlText,
 			"</body>\n</html>",
-		]
+		)
 	)
 	with codecs.open(dest, "w", "utf-8") as f:
 		f.write(docText)

--- a/sconstruct
+++ b/sconstruct
@@ -77,9 +77,6 @@ elif env["version"] is not None:
 if "channel" in env and env["channel"] is not None:
 	env["addon_updateChannel"] = env["channel"]
 
-buildVars.addon_info["addon_version"] = env["addon_version"]
-buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
-
 
 addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
 addon = env.NVDAAddon(addonFile, env.Dir(addonDir), excludePatterns=buildVars.excludedFiles)

--- a/sconstruct
+++ b/sconstruct
@@ -30,6 +30,7 @@ EnsurePythonVersion(3, 10)
 sys.dont_write_bytecode = True
 
 import buildVars  # NOQA: E402
+from site_scons.site_tools.NVDATool.typings import Strable # NOQA: E402
 
 
 def validateVersionNumber(key: str, val: str, _):
@@ -69,7 +70,7 @@ def translatedManifestGenerator(target: list[FS.Entry], source: list[FS.Entry], 
 
 def format_nested_section(
 	section_name: str,
-	data: Mapping[str, Mapping[str, str]]
+	data: Mapping[str, Mapping[str, Strable]]
 ) -> str:
 	lines = [f"\n[{section_name}]"]
 	for item_name, inner_dict in data.items():
@@ -107,7 +108,7 @@ def generateTranslatedManifest(source: str, language: str, dest: str):
 		manifest_template = f.read()
 	manifest = manifest_template.format(**vars)
 
-	def _format_section_only_with_displayName(section_name: str, data: Mapping[str, Mapping[str, str]]) -> str:
+	def _format_section_only_with_displayName(section_name: str, data: Mapping[str, Mapping[str, Strable]]) -> str:
 		lines = [f"\n[{section_name}]"]
 		for item, inner_dict in data.items():
 			lines.append(f"[[{item}]]")

--- a/sconstruct
+++ b/sconstruct
@@ -127,8 +127,6 @@ if "channel" in env and env["channel"] is not None:
 buildVars.addon_info["addon_version"] = env["addon_version"]
 buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
 
-addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
-
 
 def addonGenerator(target, source, env, for_signature):
 	action = env.Action(
@@ -266,6 +264,7 @@ def expandGlobs(patterns: Iterable[str]) -> list:
 	return [env.File(f) for pattern in patterns for f in base.glob(pattern.lstrip('/'))]
 
 
+addonFile = env.File("${addon_name}-${addon_version}.nvda-addon")
 addon = env.NVDAAddon(addonFile, env.Dir(addonDir))
 
 langDirs = [f for f in env.Glob(localeDir/"*")]

--- a/sconstruct
+++ b/sconstruct
@@ -18,7 +18,10 @@ from typing import Final
 # To avoid PyRight `reportUndefinedVariable` errors about them they are imported explicitly.
 # When using other  Scons functions please add them to the line below.
 from SCons.Script import EnsurePythonVersion, Variables, BoolVariable, Environment, Builder, Copy
+
+# Imports for type hints
 from SCons.Node import FS
+from SCons.Action import CommandAction
 
 # Add-on localization exchange facility and the template requires Python 3.10.
 # For best practice, use Python 3.11 or later to align with NVDA development.
@@ -85,7 +88,7 @@ def md2html(source: str|Path, dest: str):
 		f.write(docText)
 
 
-def mdTool(env):
+def mdTool(env: Environment):
 	mdAction = env.Action(
 		lambda target, source, env: md2html(source[0].path, target[0].path),
 		lambda target, source, env: f"Generating {target[0]}",
@@ -136,7 +139,7 @@ buildVars.addon_info["addon_version"] = env["addon_version"]
 buildVars.addon_info["addon_updateChannel"] = env["addon_updateChannel"]
 
 
-def addonGenerator(target, source, env, for_signature):
+def addonGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
 	action = env.Action(
 		lambda target, source, env: createAddonBundleFromPath(source[0].abspath, target[0].abspath) and None,
 		lambda target, source, env: f"Generating Addon {target[0]}",
@@ -144,7 +147,7 @@ def addonGenerator(target, source, env, for_signature):
 	return action
 
 
-def manifestGenerator(target, source, env, for_signature):
+def manifestGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
 	action = env.Action(
 		lambda target, source, env: generateManifest(source[0].abspath, target[0].abspath) and None,
 		lambda target, source, env: f"Generating manifest {target[0]}",
@@ -152,7 +155,7 @@ def manifestGenerator(target, source, env, for_signature):
 	return action
 
 
-def translatedManifestGenerator(target, source, env, for_signature):
+def translatedManifestGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
 	dir = Path(str(source[0])).absolute().parents[1]
 	lang = dir.name
 	action = env.Action(
@@ -204,7 +207,7 @@ def createAddonBundleFromPath(path: str|Path, dest: str):
 	return dest
 
 
-def generateManifest(source, dest):
+def generateManifest(source: str, dest: str):
 	# Prepare the root manifest section
 	addon_info = buildVars.addon_info
 	with codecs.open(source, "r", "utf-8") as f:
@@ -233,7 +236,7 @@ def generateManifest(source, dest):
 		f.write(manifest)
 
 
-def generateTranslatedManifest(source, language, out):
+def generateTranslatedManifest(source: str, language: str, out: str):
 	_ = gettext.translation("nvda", localedir=localeDir, languages=[language]).gettext
 	vars = {}
 	for var in ("addon_summary", "addon_description"):

--- a/site_scons/site_tools/NVDATool/__init__.py
+++ b/site_scons/site_tools/NVDATool/__init__.py
@@ -16,8 +16,7 @@ The following environment variables are required to create the manifest:
 
 The following environment variables are required to build the HTML:
 
-- localeDir: str
-- localeFileName: str
+- moFile: str|Path|None
 - mdExtensions: list[str]
 - addon_info: .typings.AddonInfo
 
@@ -85,16 +84,13 @@ def generate(env: Environment):
 		src_siffix=".ini.tpl"
 	)
 
-	env.SetDefault(localeDir = Path("locale/"))
-	env.SetDefault(localeFileName = "messages")
 	env.SetDefault(mdExtensions = {})
 
 	mdAction = env.Action(
 		lambda target, source, env: md2html(
 			source[0].path,
 			target[0].path,
-			localeDir=env["localeDir"],
-			loacleFileName=env["localeFileName"],
+			moFile=env["moFile"].path if env["moFile"] else None,
 			mdExtensions=env["mdExtensions"],
 			addon_info=env["addon_info"],
 		) and None,

--- a/site_scons/site_tools/NVDATool/__init__.py
+++ b/site_scons/site_tools/NVDATool/__init__.py
@@ -19,8 +19,7 @@ The following environment variables are required to build the HTML:
 - localeDir: str
 - localeFileName: str
 - mdExtensions: list[str]
-- addon_summary: str
-- addon_version: str
+- addon_info: .typings.AddonInfo
 
 """
 
@@ -97,8 +96,7 @@ def generate(env: Environment):
 			localeDir=env["localeDir"],
 			loacleFileName=env["localeFileName"],
 			mdExtensions=env["mdExtensions"],
-			addonSummary=env["addon_summary"],
-			addonVersion=env["addon_version"]
+			addon_info=env["addon_info"],
 		) and None,
 		lambda target, source, env: f"Generating {target[0]}",
 	)

--- a/site_scons/site_tools/NVDATool/__init__.py
+++ b/site_scons/site_tools/NVDATool/__init__.py
@@ -10,7 +10,6 @@ Builders:
 The following environment variables are required to create the manifest:
 
 - addon_info: .typing.AddonInfo
-- lcaledir: str | pathlib.Path
 - brailleTables: .typings.BrailleTables
 - symbolDictionaries: .typings.SymbolDictionaries
 
@@ -28,13 +27,11 @@ from .manifests import generateManifest, generateTranslatedManifest
 
 
 def translatedManifestGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
-	dir = Path(str(source[0])).absolute().parents[1]
-	lang = dir.name
 	action = env.Action(
 		lambda target, source, env: generateTranslatedManifest(
 			source[1].abspath,
 			target[0].abspath,
-			lang, env["localedir"],
+			mo=source[0].abspath,
 			addon_info=env["addon_info"],
 			brailleTables=env["brailleTables"],
 			symbolDictionaries=env["symbolDictionaries"],

--- a/site_scons/site_tools/NVDATool/__init__.py
+++ b/site_scons/site_tools/NVDATool/__init__.py
@@ -4,12 +4,44 @@ This tool generates NVDA extensions.
 Builders:
 
 - NVDAAddon: Creates a .nvda-addon zip file. Requires the `excludePatterns` environment variable.
+- NVDAManifest: Creates the manifest.ini file.
+- NVDATranslatedManifest: Creates the manifest.ini file with only translated information.
+
+The following environment variables are required to create the manifest:
+
+- addon_info: .typing.AddonInfo
+- lcaledir: str | pathlib.Path
+- brailleTables: .typings.BrailleTables
+- symbolDictionaries: .typings.SymbolDictionaries
 
 """
 
+from pathlib import Path
+
 from SCons.Script import Environment, Builder
+from SCons.Node import FS
+from SCons.Action import CommandAction
 
 from .addon import createAddonBundleFromPath
+from .manifests import generateManifest, generateTranslatedManifest
+
+
+
+def translatedManifestGenerator(target: list[FS.Entry], source: list[FS.Entry], env: Environment, for_signature: bool) -> CommandAction:
+	dir = Path(str(source[0])).absolute().parents[1]
+	lang = dir.name
+	action = env.Action(
+		lambda target, source, env: generateTranslatedManifest(
+			source[1].abspath,
+			target[0].abspath,
+			lang, env["localedir"],
+			addon_info=env["addon_info"],
+			brailleTables=env["brailleTables"],
+			symbolDictionaries=env["symbolDictionaries"],
+		) and None,
+		lambda target, source, env: f"Generating translated manifest {target[0]}",
+	)
+	return action
 
 
 
@@ -27,6 +59,28 @@ def generate(env: Environment):
 		suffix=".nvda-addon",
 		src_suffix="/"
 	)
+
+	env.SetDefault(brailleTables={})
+	env.SetDefault(symbolDictionaries={})
+
+	manifestAction = env.Action(
+		lambda target, source, env: generateManifest(
+			source[0].abspath,
+			target[0].abspath,
+			addon_info=env["addon_info"],
+			brailleTables=env["brailleTables"],
+			symbolDictionaries=env["symbolDictionaries"],
+		) and None,
+		lambda target, source, env: f"Generating manifest {target[0]}",
+	)
+	env["BUILDERS"]["NVDAManifest"] = Builder(
+		action=manifestAction,
+		suffix=".ini",
+		src_siffix=".ini.tpl"
+	)
+
+	env["BUILDERS"]["NVDATranslatedManifest"] = Builder(generator=translatedManifestGenerator)
+
 
 def exists():
 	return True

--- a/site_scons/site_tools/NVDATool/__init__.py
+++ b/site_scons/site_tools/NVDATool/__init__.py
@@ -1,0 +1,32 @@
+"""
+This tool generates NVDA extensions.
+
+Builders:
+
+- NVDAAddon: Creates a .nvda-addon zip file. Requires the `excludePatterns` environment variable.
+
+"""
+
+from SCons.Script import Environment, Builder
+
+from .addon import createAddonBundleFromPath
+
+
+
+def generate(env: Environment):
+	env.SetDefault(excludePatterns=tuple())
+
+	addonAction = env.Action(
+		lambda target, source, env: createAddonBundleFromPath(
+			source[0].abspath, target[0].abspath, env["excludePatterns"]
+		) and None,
+		lambda target, source, env: f"Generating Addon {target[0]}",
+	)
+	env["BUILDERS"]["NVDAAddon"] = Builder(
+		action=addonAction,
+		suffix=".nvda-addon",
+		src_suffix="/"
+	)
+
+def exists():
+	return True

--- a/site_scons/site_tools/NVDATool/addon.py
+++ b/site_scons/site_tools/NVDATool/addon.py
@@ -1,0 +1,24 @@
+import zipfile
+from collections.abc import Iterable
+from pathlib import Path
+
+
+
+def matchesNoPatterns(path: Path, patterns: Iterable[str]) -> bool:
+	"""Checks if the path, the first argument, does not match any of the patterns passed as the second argument."""
+	return not any((path.match(pattern) for pattern in patterns))
+
+
+def createAddonBundleFromPath(path: str|Path, dest: str, excludePatterns: Iterable[str]):
+	"""Creates a bundle from a directory that contains an addon manifest file."""
+	if isinstance(path, str):
+		path = Path(path)
+	basedir = path.absolute()
+	with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as z:
+		for p in basedir.rglob("*"):
+			if p.is_dir():
+				continue
+			pathInBundle = p.relative_to(basedir)
+			if matchesNoPatterns(pathInBundle, excludePatterns):
+				z.write(p, pathInBundle)
+	return dest

--- a/site_scons/site_tools/NVDATool/docs.py
+++ b/site_scons/site_tools/NVDATool/docs.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import markdown
 
+from .typings import AddonInfo
+
 
 
 def md2html(
@@ -14,8 +16,7 @@ def md2html(
 		localeDir: Path,
 		loacleFileName: str,
 		mdExtensions: list[str],
-		addonSummary: str,
-		addonVersion: str
+		addon_info: AddonInfo
 	):
 	if isinstance(source, str):
 		source = Path(source)
@@ -29,10 +30,10 @@ def md2html(
 			localedir=localeDir,
 			languages=[localeLang]
 		).gettext
-		summary = _(addonSummary)
+		summary = _(addon_info["addon_summary"])
 	except Exception:
-		summary = addonSummary
-	title = f"{summary} {addonVersion}"
+		summary = addon_info["addon_summary"]
+	title = f"{summary} {addon_info["addon_version"]}"
 	headerDic = {
 		'[[!meta title="': "# ",
 		'"]]': " #",

--- a/site_scons/site_tools/NVDATool/docs.py
+++ b/site_scons/site_tools/NVDATool/docs.py
@@ -37,7 +37,8 @@ def md2html(
 		summary = addon_info["addon_summary"]
 	else:
 		summary = _(addon_info["addon_summary"])
-	title = f"{summary} {addon_info["addon_version"]}"
+	version = addon_info["addon_version"]
+	title = f"{summary} {version}"
 	headerDic = {
 		'[[!meta title="': "# ",
 		'"]]': " #",

--- a/site_scons/site_tools/NVDATool/docs.py
+++ b/site_scons/site_tools/NVDATool/docs.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import markdown
 
+from . import utils
 from .typings import AddonInfo
 
 
@@ -12,8 +13,7 @@ def md2html(
 		source: str|Path,
 		dest: str|Path,
 		*,
-		localeDir: Path,
-		loacleFileName: str,
+		moFile: str|Path|None,
 		mdExtensions: list[str],
 		addon_info: AddonInfo
 	):
@@ -21,19 +21,22 @@ def md2html(
 		source = Path(source)
 	if isinstance(dest, str):
 		dest = Path(dest)
+	if isinstance(moFile, str):
+		moFile = Path(moFile)
 
 	# Use extensions if defined.
 	localeLang = source.parent.name
 	lang = localeLang.replace("_", "-")
 	try:
-		_ = gettext.translation(
-			loacleFileName,
-			localedir=localeDir,
-			languages=[localeLang]
-		).gettext
-		summary = _(addon_info["addon_summary"])
+		if moFile is not None:
+			with moFile.open("rb") as f:
+				_ = gettext.GNUTranslations(f).gettext
+		else:
+			_ = utils._
 	except Exception:
 		summary = addon_info["addon_summary"]
+	else:
+		summary = _(addon_info["addon_summary"])
 	title = f"{summary} {addon_info["addon_version"]}"
 	headerDic = {
 		'[[!meta title="': "# ",

--- a/site_scons/site_tools/NVDATool/docs.py
+++ b/site_scons/site_tools/NVDATool/docs.py
@@ -1,6 +1,5 @@
 
 import gettext
-import codecs
 from pathlib import Path
 
 import markdown
@@ -11,7 +10,7 @@ from .typings import AddonInfo
 
 def md2html(
 		source: str|Path,
-		dest: str,
+		dest: str|Path,
 		*,
 		localeDir: Path,
 		loacleFileName: str,
@@ -20,6 +19,8 @@ def md2html(
 	):
 	if isinstance(source, str):
 		source = Path(source)
+	if isinstance(dest, str):
+		dest = Path(dest)
 
 	# Use extensions if defined.
 	localeLang = source.parent.name
@@ -38,7 +39,7 @@ def md2html(
 		'[[!meta title="': "# ",
 		'"]]': " #",
 	}
-	with codecs.open(str(source), "r", "utf-8") as f:
+	with source.open("r") as f:
 		mdText = f.read()
 	for k, v in headerDic.items():
 		mdText = mdText.replace(k, v, 1)
@@ -58,5 +59,5 @@ def md2html(
 			"</body>\n</html>",
 		)
 	)
-	with codecs.open(dest, "w", "utf-8") as f:
-		f.write(docText)
+	with dest.open("w") as f:
+		f.write(docText) # type: ignore

--- a/site_scons/site_tools/NVDATool/docs.py
+++ b/site_scons/site_tools/NVDATool/docs.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import markdown
 
-from . import utils
 from .typings import AddonInfo
 
 
@@ -24,21 +23,16 @@ def md2html(
 	if isinstance(moFile, str):
 		moFile = Path(moFile)
 
-	# Use extensions if defined.
-	localeLang = source.parent.name
-	lang = localeLang.replace("_", "-")
 	try:
-		if moFile is not None:
-			with moFile.open("rb") as f:
-				_ = gettext.GNUTranslations(f).gettext
-		else:
-			_ = utils._
+		with moFile.open("rb") as f:
+			_ = gettext.GNUTranslations(f).gettext
 	except Exception:
 		summary = addon_info["addon_summary"]
 	else:
 		summary = _(addon_info["addon_summary"])
 	version = addon_info["addon_version"]
 	title = f"{summary} {version}"
+	lang = source.parent.name.replace("_", "-")
 	headerDic = {
 		'[[!meta title="': "# ",
 		'"]]': " #",

--- a/site_scons/site_tools/NVDATool/docs.py
+++ b/site_scons/site_tools/NVDATool/docs.py
@@ -1,27 +1,9 @@
-"""
-This tool allows you to generate HTML files from Markdown.
-
-Adds the following Builder to the constructed environment:
-
-- md2html: Build HTML from Markdown
-
-The following variables are required in the environment:
-
-- localeDir
-- localeFileName
-- mdExtensions
-- addon_summary
-- addon_version
-
-
-"""
 
 import gettext
 import codecs
 from pathlib import Path
 
 import markdown
-from SCons.Script import Environment
 
 
 
@@ -77,32 +59,3 @@ def md2html(
 	)
 	with codecs.open(dest, "w", "utf-8") as f:
 		f.write(docText)
-
-
-def generate(env: Environment):
-	env.SetDefault(localeDir = Path("locale/"))
-	env.SetDefault(localeFileName = "messages")
-	env.SetDefault(mdExtensions = {})
-
-	mdAction = env.Action(
-		lambda target, source, env: md2html(
-			source[0].path,
-			target[0].path,
-			localeDir=env["localeDir"],
-			loacleFileName=env["localeFileName"],
-			mdExtensions=env["mdExtensions"],
-			addonSummary=env["addon_summary"],
-			addonVersion=env["addon_version"]
-		) and None,
-		lambda target, source, env: f"Generating {target[0]}",
-	)
-	mdBuilder = env.Builder(
-		action=mdAction,
-		suffix=".html",
-		src_suffix=".md",
-	)
-	env["BUILDERS"]["md2html"] = mdBuilder
-
-
-def exists():
-	return True

--- a/site_scons/site_tools/NVDATool/manifests.py
+++ b/site_scons/site_tools/NVDATool/manifests.py
@@ -4,18 +4,8 @@ import gettext
 from collections.abc import Mapping
 
 from .typings import AddonInfo, BrailleTables, SymbolDictionaries, Strable
+from .utils import format_nested_section
 
-
-def format_nested_section(
-	section_name: str,
-	data: Mapping[str, Mapping[str, Strable]]
-) -> str:
-	lines = [f"\n[{section_name}]"]
-	for item_name, inner_dict in data.items():
-		lines.append(f"[[{item_name}]]")
-		for key, val in inner_dict.items():
-			lines.append(f"{key} = {val}")
-	return "\n".join(lines) + "\n"
 
 
 def generateManifest(

--- a/site_scons/site_tools/NVDATool/manifests.py
+++ b/site_scons/site_tools/NVDATool/manifests.py
@@ -1,9 +1,9 @@
 
 import codecs
 import gettext
-from collections.abc import Mapping
+from functools import partial
 
-from .typings import AddonInfo, BrailleTables, SymbolDictionaries, Strable
+from .typings import AddonInfo, BrailleTables, SymbolDictionaries
 from .utils import format_nested_section
 
 
@@ -50,13 +50,11 @@ def generateTranslatedManifest(
 		manifest_template = f.read()
 	manifest = manifest_template.format(**vars)
 
-	def _format_section_only_with_displayName(section_name: str, data: Mapping[str, Mapping[str, Strable]]) -> str:
-		lines = [f"\n[{section_name}]"]
-		for item, inner_dict in data.items():
-			lines.append(f"[[{item}]]")
-			# Fetch display name only.
-			lines.append(f"displayName = {_(str(inner_dict['displayName']))}")
-		return "\n".join(lines) + "\n"
+	_format_section_only_with_displayName = partial(
+		format_nested_section,
+		include_only_keys = ("displayName",),
+		_ = _,
+	)
 
 	# Add additional manifest sections such as custom braile tables
 	# Custom braille translation tables

--- a/site_scons/site_tools/NVDATool/manifests.py
+++ b/site_scons/site_tools/NVDATool/manifests.py
@@ -3,8 +3,7 @@ import codecs
 import gettext
 from collections.abc import Mapping
 
-from site_scons.site_tools.NVDATool.typings import AddonInfo, BrailleTables, SymbolDictionaries, Strable # NOQA: E402
-
+from .typings import AddonInfo, BrailleTables, SymbolDictionaries, Strable
 
 
 def format_nested_section(

--- a/site_scons/site_tools/NVDATool/manifests.py
+++ b/site_scons/site_tools/NVDATool/manifests.py
@@ -1,0 +1,81 @@
+
+import codecs
+import gettext
+from collections.abc import Mapping
+
+from site_scons.site_tools.NVDATool.typings import AddonInfo, BrailleTables, SymbolDictionaries, Strable # NOQA: E402
+
+
+
+def format_nested_section(
+	section_name: str,
+	data: Mapping[str, Mapping[str, Strable]]
+) -> str:
+	lines = [f"\n[{section_name}]"]
+	for item_name, inner_dict in data.items():
+		lines.append(f"[[{item_name}]]")
+		for key, val in inner_dict.items():
+			lines.append(f"{key} = {val}")
+	return "\n".join(lines) + "\n"
+
+
+def generateManifest(
+		source: str,
+		dest: str,
+		addon_info: AddonInfo,
+		brailleTables: BrailleTables,
+		symbolDictionaries: SymbolDictionaries,
+	):
+	# Prepare the root manifest section
+	with codecs.open(source, "r", "utf-8") as f:
+		manifest_template = f.read()
+	manifest = manifest_template.format(**addon_info)
+	# Add additional manifest sections such as custom braile tables
+	# Custom braille translation tables
+	if brailleTables:
+		manifest += format_nested_section("brailleTables", brailleTables)
+
+	# Custom speech symbol dictionaries
+	if symbolDictionaries:
+		manifest += format_nested_section("symbolDictionaries", symbolDictionaries)
+
+	with codecs.open(dest, "w", "utf-8") as f:
+		f.write(manifest)
+
+
+def generateTranslatedManifest(
+		source: str,
+		dest: str,
+		language: str,
+		localeDir: str,
+		addon_info: AddonInfo,
+		brailleTables: BrailleTables,
+		symbolDictionaries: SymbolDictionaries,
+	):
+	_ = gettext.translation("nvda", localedir=localeDir, languages=[language]).gettext
+	vars: dict[str, str] = {}
+	for var in ("addon_summary", "addon_description"):
+		vars[var] = _(addon_info[var])
+	with codecs.open(source, "r", "utf-8") as f:
+		manifest_template = f.read()
+	manifest = manifest_template.format(**vars)
+
+	def _format_section_only_with_displayName(section_name: str, data: Mapping[str, Mapping[str, Strable]]) -> str:
+		lines = [f"\n[{section_name}]"]
+		for item, inner_dict in data.items():
+			lines.append(f"[[{item}]]")
+			# Fetch display name only.
+			lines.append(f"displayName = {_(str(inner_dict['displayName']))}")
+		return "\n".join(lines) + "\n"
+
+	# Add additional manifest sections such as custom braile tables
+	# Custom braille translation tables
+	if brailleTables:
+		manifest += _format_section_only_with_displayName("brailleTables", brailleTables)
+
+	# Custom speech symbol dictionaries
+	if symbolDictionaries:
+		manifest += _format_section_only_with_displayName("symbolDictionaries", symbolDictionaries)
+
+	with codecs.open(dest, "w", "utf-8") as f:
+		f.write(manifest)

--- a/site_scons/site_tools/NVDATool/manifests.py
+++ b/site_scons/site_tools/NVDATool/manifests.py
@@ -46,13 +46,14 @@ def generateManifest(
 def generateTranslatedManifest(
 		source: str,
 		dest: str,
-		language: str,
-		localeDir: str,
+		*,
+		mo: str,
 		addon_info: AddonInfo,
 		brailleTables: BrailleTables,
 		symbolDictionaries: SymbolDictionaries,
 	):
-	_ = gettext.translation("nvda", localedir=localeDir, languages=[language]).gettext
+	with open(mo, "rb") as f:
+		_ = gettext.GNUTranslations(f).gettext
 	vars: dict[str, str] = {}
 	for var in ("addon_summary", "addon_description"):
 		vars[var] = _(addon_info[var])

--- a/site_scons/site_tools/NVDATool/typings.py
+++ b/site_scons/site_tools/NVDATool/typings.py
@@ -1,0 +1,18 @@
+from typing import TypedDict
+
+
+
+class AddonInfo(TypedDict):
+	addon_name: str
+	addon_summary: str
+	addon_description: str
+	addon_version: str
+	addon_author: str
+	addon_url: str|None
+	addon_sourceURL: str|None
+	addon_docFileName: str
+	addon_minimumNVDAVersion: str|None
+	addon_lastTestedNVDAVersion: str|None
+	addon_updateChannel: str|None
+	addon_license: str|None
+	addon_licenseURL: str|None

--- a/site_scons/site_tools/NVDATool/typings.py
+++ b/site_scons/site_tools/NVDATool/typings.py
@@ -16,3 +16,19 @@ class AddonInfo(TypedDict):
 	addon_updateChannel: str|None
 	addon_license: str|None
 	addon_licenseURL: str|None
+
+
+class BrailleTableAttributes(TypedDict):
+    displayName: str
+    contracted: bool
+    output: bool
+    input: bool
+
+
+class SymbolDictionaryAttributes(TypedDict):
+    displayName: str
+    mandatory: bool
+
+
+BrailleTables = dict[str, BrailleTableAttributes]
+SymbolDictionaries = dict[str, SymbolDictionaryAttributes]

--- a/site_scons/site_tools/NVDATool/typings.py
+++ b/site_scons/site_tools/NVDATool/typings.py
@@ -1,4 +1,4 @@
-from typing import TypedDict, Protocol, override
+from typing import TypedDict, Protocol
 
 
 
@@ -35,5 +35,4 @@ SymbolDictionaries = dict[str, SymbolDictionaryAttributes]
 
 
 class Strable(Protocol):
-	@override
 	def __str__(self) -> str: ...

--- a/site_scons/site_tools/NVDATool/typings.py
+++ b/site_scons/site_tools/NVDATool/typings.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import TypedDict, Protocol, override
 
 
 
@@ -32,3 +32,8 @@ class SymbolDictionaryAttributes(TypedDict):
 
 BrailleTables = dict[str, BrailleTableAttributes]
 SymbolDictionaries = dict[str, SymbolDictionaryAttributes]
+
+
+class Strable(Protocol):
+	@override
+	def __str__(self) -> str: ...

--- a/site_scons/site_tools/NVDATool/utils.py
+++ b/site_scons/site_tools/NVDATool/utils.py
@@ -1,0 +1,7 @@
+
+def _(arg: str) -> str:
+	"""
+	A function that passes the string to it without doing anything to it.
+	Needed for recognizing strings for translation by Gettext.
+	"""
+	return arg

--- a/site_scons/site_tools/NVDATool/utils.py
+++ b/site_scons/site_tools/NVDATool/utils.py
@@ -1,3 +1,8 @@
+from collections.abc import Mapping
+
+from .typings import Strable
+
+
 
 def _(arg: str) -> str:
 	"""
@@ -5,3 +10,15 @@ def _(arg: str) -> str:
 	Needed for recognizing strings for translation by Gettext.
 	"""
 	return arg
+
+
+def format_nested_section(
+	section_name: str,
+	data: Mapping[str, Mapping[str, Strable]]
+) -> str:
+	lines = [f"\n[{section_name}]"]
+	for item_name, inner_dict in data.items():
+		lines.append(f"[[{item_name}]]")
+		for key, val in inner_dict.items():
+			lines.append(f"{key} = {val}")
+	return "\n".join(lines) + "\n"

--- a/site_scons/site_tools/NVDATool/utils.py
+++ b/site_scons/site_tools/NVDATool/utils.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Callable, Container, Mapping
 
 from .typings import Strable
 
@@ -14,11 +14,15 @@ def _(arg: str) -> str:
 
 def format_nested_section(
 	section_name: str,
-	data: Mapping[str, Mapping[str, Strable]]
+	data: Mapping[str, Mapping[str, Strable]],
+	include_only_keys: Container[str]|None = None,
+	_: Callable[[str], str] = _,
 ) -> str:
 	lines = [f"\n[{section_name}]"]
 	for item_name, inner_dict in data.items():
 		lines.append(f"[[{item_name}]]")
 		for key, val in inner_dict.items():
-			lines.append(f"{key} = {val}")
+			if include_only_keys and key not in include_only_keys:
+				continue
+			lines.append(f"{key} = {_(str(val))}")
 	return "\n".join(lines) + "\n"

--- a/site_scons/site_tools/mdTool/__init__.py
+++ b/site_scons/site_tools/mdTool/__init__.py
@@ -3,7 +3,7 @@ This tool allows you to generate HTML files from Markdown.
 
 Adds the following Builder to the constructed environment:
 
-- markdown: Build HTML from Markdown
+- md2html: Build HTML from Markdown
 
 The following variables are required in the environment:
 
@@ -101,7 +101,7 @@ def generate(env: Environment):
 		suffix=".html",
 		src_suffix=".md",
 	)
-	env["BUILDERS"]["markdown"] = mdBuilder
+	env["BUILDERS"]["md2html"] = mdBuilder
 
 
 def exists():

--- a/site_scons/site_tools/mdTool/__init__.py
+++ b/site_scons/site_tools/mdTool/__init__.py
@@ -93,7 +93,7 @@ def generate(env: Environment):
 			mdExtensions=env["mdExtensions"],
 			addonSummary=env["addon_summary"],
 			addonVersion=env["addon_version"]
-		),
+		) and None,
 		lambda target, source, env: f"Generating {target[0]}",
 	)
 	mdBuilder = env.Builder(

--- a/site_scons/site_tools/mdTool/__init__.py
+++ b/site_scons/site_tools/mdTool/__init__.py
@@ -1,0 +1,108 @@
+"""
+This tool allows you to generate HTML files from Markdown.
+
+Adds the following Builder to the constructed environment:
+
+- markdown: Build HTML from Markdown
+
+The following variables are required in the environment:
+
+- localeDir
+- localeFileName
+- mdExtensions
+- addon_summary
+- addon_version
+
+
+"""
+
+import gettext
+import codecs
+from pathlib import Path
+
+import markdown
+from SCons.Script import Environment
+
+
+
+def md2html(
+		source: str|Path,
+		dest: str,
+		*,
+		localeDir: Path,
+		loacleFileName: str,
+		mdExtensions: list[str],
+		addonSummary: str,
+		addonVersion: str
+	):
+	if isinstance(source, str):
+		source = Path(source)
+
+	# Use extensions if defined.
+	localeLang = source.parent.name
+	lang = localeLang.replace("_", "-")
+	try:
+		_ = gettext.translation(
+			loacleFileName,
+			localedir=localeDir,
+			languages=[localeLang]
+		).gettext
+		summary = _(addonSummary)
+	except Exception:
+		summary = addonSummary
+	title = f"{summary} {addonVersion}"
+	headerDic = {
+		'[[!meta title="': "# ",
+		'"]]': " #",
+	}
+	with codecs.open(str(source), "r", "utf-8") as f:
+		mdText = f.read()
+	for k, v in headerDic.items():
+		mdText = mdText.replace(k, v, 1)
+	htmlText = markdown.markdown(mdText, extensions=mdExtensions)
+	# Optimization: build resulting HTML text in one go instead of writing parts separately.
+	docText = "\n".join(
+		(
+			"<!DOCTYPE html>",
+			f'<html lang="{lang}">',
+			"<head>",
+			'<meta charset="UTF-8">',
+			'<meta name="viewport" content="width=device-width, initial-scale=1.0">',
+			'<link rel="stylesheet" type="text/css" href="../style.css" media="screen">',
+			f"<title>{title}</title>",
+			"</head>\n<body>",
+			htmlText,
+			"</body>\n</html>",
+		)
+	)
+	with codecs.open(dest, "w", "utf-8") as f:
+		f.write(docText)
+
+
+def generate(env: Environment):
+	env.SetDefault(localeDir = Path("locale/"))
+	env.SetDefault(localeFileName = "messages")
+	env.SetDefault(mdExtensions = {})
+
+	mdAction = env.Action(
+		lambda target, source, env: md2html(
+			source[0].path,
+			target[0].path,
+			localeDir=env["localeDir"],
+			loacleFileName=env["localeFileName"],
+			mdExtensions=env["mdExtensions"],
+			addonSummary=env["addon_summary"],
+			addonVersion=env["addon_version"]
+		),
+		lambda target, source, env: f"Generating {target[0]}",
+	)
+	mdBuilder = env.Builder(
+		action=mdAction,
+		suffix=".html",
+		src_suffix=".md",
+	)
+	env["BUILDERS"]["markdown"] = mdBuilder
+
+
+def exists():
+	return True


### PR DESCRIPTION
- Partially switched to using pathlib instead of os.path.
- Added type hints.
- Now buildVars.pythonSources and i18n are interpreted by the `pathlib.Path().glob` function instead of `SCons.Script.Glob`. This is done to improve supported patterns, such as `addon/**.py` instead of the more limited `addon/*/*.py`.