### PR TITLE
NVDATool.docs - md2html: Fix encoding bug

### DIFF
--- a/site_scons/site_tools/NVDATool/docs.py
+++ b/site_scons/site_tools/NVDATool/docs.py
@@ -37,7 +37,7 @@ def md2html(
 		'[[!meta title="': "# ",
 		'"]]': " #",
 	}
-	with source.open("r") as f:
+	with source.open("r", encoding="utf-8") as f:
 		mdText = f.read()
 	for k, v in headerDic.items():
 		mdText = mdText.replace(k, v, 1)
@@ -57,5 +57,5 @@ def md2html(
 			"</body>\n</html>",
 		)
 	)
-	with dest.open("w") as f:
+	with dest.open("w", encoding="utf-8") as f:
 		f.write(docText) # type: ignore


### PR DESCRIPTION
### Issue

Running scons on Windows platform (cmd or powershell) fails with the following error (example from winMag add-on compilation):

```
scons: Reading SConscript files ...                                                                                     
scons: done reading SConscript files.                                                                                   
scons: Building targets ...                                                                                             
Compiling translation addon\locale\bg\LC_MESSAGES\nvda.po                                                               
Generating addon\doc\bg\readme.html                                                                                     
scons: *** [addon\doc\bg\readme.html] UnicodeDecodeError : 'charmap' codec can't decode byte 0x90 in position 52: character maps to <undefined>                                                                                                 
Traceback (most recent call last):                                                                                      
  File "C:\Users\myUserName\AppData\Local\Programs\Python\Python311-32\Lib\site-packages\SCons\Action.py", line 1434, in execute                                                                                                                  
    result = self.execfunction(target=target, source=rsources, env=env)                                                 
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                 
  File "C:\Users\myUserName\Documents\DevP\GIT\winMag\site_scons\site_tools\NVDATool\__init__.py", line 88, in <lambda>   
    lambda target, source, env: md2html(                                                                                
                                ^^^^^^^^                                                                                
  File "C:\Users\myUserName\Documents\DevP\GIT\winMag\site_scons\site_tools\NVDATool\docs.py", line 41, in md2html        
    mdText = f.read()                                                                                                   
             ^^^^^^^^                                                                                                   
  File "C:\Users\myUserName\AppData\Local\Programs\Python\Python311-32\Lib\encodings\cp1252.py", line 23, in decode       
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]                                                   
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                      
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 52: character maps to <undefined>                
scons: building terminated because of errors.                                                                           
``` 

According to Python's [`open` documentation](https://docs.python.org/3/library/functions.html#open):
> In text mode, if encoding is not specified the encoding used is platform-dependent: locale.getencoding() is called to get the current locale encoding.

The encoding parameter was removed during a recent modernization work on the template's code. On Linux this had no impact since it uses UTF-8 as locale encoding. But on Windows system, this cause the wrong encoding issue.

### Solution
Explicitly provide the encoding parameter to ensure UTF-8 read/write to text files.

### Test

Done on winMag add-on.

### To go further

Test the add-on template both on Windows and Linux platforms in the future to avoid such regression.
