### PR TITLE
Make the new add-on template repo a link in the documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # NVDA Add-on Scons Template
 
-IMPORTANT: as of December 1, 2025, nvdaaddons/addonTemplate repository is archived. Please use nvaccess/addonTemplate repository.
+IMPORTANT: as of December 1, 2025, nvdaaddons/addonTemplate repository is archived. Please use [nvaccess/addonTemplate](https://github.com/nvaccess/AddonTemplate) repository.
 
 This package contains a basic template structure for NVDA add-on development, building, distribution and localization.
 For details about NVDA add-on development, please see the [NVDA Add-on Development Guide](https://github.com/nvdaaddons/DevGuide/wiki/NVDA-Add-on-Development-Guide).


### PR DESCRIPTION
### Issue
The new official repo for add-on template is now hosted by nvaccess fork, not this one (nvdaaddons). This is mentioned on top of the readme of this repo what is a good thing.

Unfortunately, when searching for "NVDA add-on template", Google still directs us to the current old repo (nvdaaddons one).

### Solution
For more efficiency, make the new repo mentioned in the readme a link, so that one can click it and go immediately to the new repo.
